### PR TITLE
Show 403 page on insufficient permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@
 ### 管理文章
 <img src="https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/dark/screenshot3.png" alt="深色模式管理文章" style="width: 100%; border-radius: 8px;">
 
-### 管理分类
-<img src="https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/dark/screenshot4.png" alt="深色模式管理分类" style="width: 100%; border-radius: 8px;">
+### 管理标签
+<img src="https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/dark/screenshot4.png" alt="深色模式管理标签" style="width: 100%; border-radius: 8px;">
 
-### 外观编辑
-<img src="https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/dark/screenshot5.png" alt="深色模式外观编辑" style="width: 100%; border-radius: 8px;">
+### 外观管理
+<img src="https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/dark/screenshot5.png" alt="深色模式外观管理" style="width: 100%; border-radius: 8px;">
 
 </div>
 </details>
@@ -140,6 +140,9 @@
 
 - **🔧 PHP 8 兼容性改进**
   - 修复侧边栏标题在 PHP 8 环境下可能的空值警告问题，优化默认显示逻辑
+
+- **🛡️ 权限不足友好提示**
+  - 权限不足时显示友好提示而非抛出异常
 
 - **💡 推荐插件体验优化**
   - 登录页与插件管理页新增配套插件推荐，提供国内镜像与 GitHub 双下载渠道链接

--- a/admin/common.php
+++ b/admin/common.php
@@ -20,7 +20,13 @@ if (!defined('__TYPECHO_ROOT_DIR__') && !@include_once __DIR__ . '/../config.inc
 \Widget\Options::alloc()->to($options);
 \Widget\User::alloc()->to($user);
 \Widget\Security::alloc()->to($security);
-\Widget\Menu::alloc()->to($menu);
+try {
+    \Widget\Menu::alloc()->to($menu);
+} catch (\Typecho\Widget\Exception $e) {
+    http_response_code(403);
+    echo '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>BooAdmin - 403 - 您的权限不足</title><style>*{margin:0;padding:0;box-sizing:border-box}body{background:#111;color:#888;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh}.c{text-align:center;padding:2rem}.code{font-size:6rem;font-weight:700;color:#333;line-height:1}.msg{color:#666;font-size:.95rem;margin-top:.75rem}.back{display:inline-block;margin-top:2rem;padding:.5rem 1.25rem;background:#1a1a1a;color:#888;border:1px solid #333;text-decoration:none;font-size:.85rem;transition:background .2s}.back:hover{background:#222}</style></head><body><div class="c"><div class="code">403</div><div class="msg">权限不足，无法访问此页面</div><a class="back" href="/">返回首页</a></div></body></html>';
+    exit;
+}
 
 /** 初始化上下文 */
 $request = $options->request;


### PR DESCRIPTION
Wrap \Widget\Menu::alloc() in a try/catch to handle \Typecho\Widget\Exception; return HTTP 403 and render a friendly "权限不足，无法访问此页面" HTML page, then exit to stop further execution. Update README: rename sections (管理分类 -> 管理标签, 外观编辑 -> 外观管理) and add a changelog entry noting the new permission-friendly prompt.