### PR TITLE
Release v1.1.18 and update assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 一款使用 TailwindCSS 精心重构的 Typecho 现代化后台主题。完全支持 Typecho 1.3.0，采用 GARFIELDTOM'S NEST CDN 进行资源加速分发，提供稳定且高效的加载体验。
 
-[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.1.17-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
+[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.1.18-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
 [![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)](LICENSE)
 ![LTS](https://img.shields.io/badge/Status-LTS%20Stable-blue?style=for-the-badge)
 
@@ -124,37 +124,14 @@
 
 ---
 
-## 🚀 v1.1.17 版本更新速递
+## 🚀 v1.1.18 版本更新速递
 
-### 特性优化
+> ⚠️ **重要提示**：
+> 
+> FontAwesome 7.1.0 版本已失效，请尽快升级到 v1.1.18 版本以确保图标正常显示
 
-- **🔄 下拉菜单交互修复**
-  - 修复了管理页面中下拉选项框因 CSS 类冲突导致的无法展开问题
-  - 优化菜单状态切换逻辑，确保在深色/浅色主题模式下稳定工作
-  - 增强键盘导航和屏幕阅读器兼容性，提升无障碍访问体验
-
-- **🏷️ 标签选择视觉增强**
-  - 优化了标签管理页面的选中状态显示效果，解决对比度不足问题
-  - 采用边框高亮 + FontAwesome 对钩图标方案，增强视觉区分度
-  - 统一深色/浅色模式下的视觉层次，确保在各种背景下清晰可见
-
-- **🎨 主题架构优化**
-  - 优化暗色/亮色模式的架构设计，使其更加统一并减少相互耦合
-  - 优化菜单的设计逻辑，移除冗余代码，并且增强了权限检查逻辑
-
-- **🔧 PHP 8 兼容性改进**
-  - 修复侧边栏标题在 PHP 8 环境下可能的空值警告问题，优化默认显示逻辑
-
-- **🛡️ 权限不足友好提示**
-  - 权限不足时显示友好提示而非抛出异常
-  - 支持自动化暗色/亮色模式切换
-
-- **💡 推荐插件体验优化**
-  - 登录页与插件管理页新增配套插件推荐，提供国内镜像与 GitHub 双下载渠道链接
-  - 提示样式适配深色/浅色主题，确保各模式下的视觉一致性
-
-- **📎 附件插入修复**
-  - 修复插入图片等附件时文件名包含多余空格的问题
+- ⬆️ 升级 FontAwesome 到 7.2.0
+- 🐛 修复因样式系统升级导致的多个已知问题
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 > BooAdmin 是一个完全开源、未压缩加密的 Typecho 后台主题，代码透明可审计。如发现安全问题，您可以根据本安全策略的说明进行处理，并且通知 BooAdmin 的开发者。
 
-[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.1.17-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
+[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.1.18-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
 [![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)](LICENSE)
 
 ---
@@ -11,8 +11,8 @@
 
 | 版本 | 状态 | 说明 |
 | :--- | :---: | :--- |
-| **v1.1.x** | ✅ 支持 | 当前主分支，持续接收安全更新 |
-| **v1.0.x** | ❌ EOL | 已停止维护，请升级至 v1.1.x |
+| **v1.1.18** | ✅ 支持 | 当前主分支，持续接收安全更新 |
+| 低于 **v1.1.17** | ❌ EOL | 资源已失效，停止维护，请升级至 v1.1.18 版本 |
 
 ---
 

--- a/admin/copyright.php
+++ b/admin/copyright.php
@@ -231,7 +231,7 @@
             <div class="booadmin-copyright-popup" id="booadminCopyrightPopup">
                 <button class="close-btn" onclick="closePopup(); event.stopPropagation();">&times;</button>
                 <h3>关于 BooAdmin</h3>
-                <div class="version">版本 1.1.17</div>
+                <div class="version">版本 1.1.18</div>
                 <div class="content">
                     <div class="left">
                         <p class="main-copy"><strong>BooAdmin 是免费开源项目。</strong>BooAdmin 的开源维护、CDN资源分发与新功能更新都离不开您的捐助。您的支持将帮助我覆盖以下成本：</p>

--- a/admin/header.php
+++ b/admin/header.php
@@ -5,21 +5,21 @@ if (!defined('__TYPECHO_ADMIN__')) {
 
 $header = '
 <!-- CSS Reset & Grid -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'normalize.css?v=1.1.17b', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'grid.css?v=1.1.17b', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'normalize.css?v=1.1.18', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'grid.css?v=1.1.18', true) . '">
 <!-- Theme Variables -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'light.css?v=1.1.17e', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'dark.css?v=1.1.17f', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'light.css?v=1.1.18', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'dark.css?v=1.1.18', true) . '">
 <!-- Component Styles -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'style.css?v=1.1.17f', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'nprogress.css?v=1.1.17e', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'style.css?v=1.1.18', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'nprogress.css?v=1.1.18', true) . '">
 <!-- NProgress -->
 <script src="' . $options->adminStaticUrl('js', 'nprogress.js', true) . '"></script>
 <!-- TailwindCSS -->
 <script src="https://cdn.garfieldtom.cool/resource/libs/tailwind/3.4.17/tailwindcss.js"></script>
 <!-- Font Awesome -->
-<script src="https://cdn.garfieldtom.cool/resource/libs/fontawesome/7.1.0/js/all.min.js"></script>
-<link href="https://cdn.garfieldtom.cool/resource/libs/fontawesome/7.1.0/css/all.min.css" rel="stylesheet">
+<script src="https://cdn.garfieldtom.cool/resource/libs/fontawesome/7.2.0/js/all.min.js"></script>
+<link href="https://cdn.garfieldtom.cool/resource/libs/fontawesome/7.2.0/css/all.min.css" rel="stylesheet">
 <!-- ECharts -->
 <script src="https://cdn.garfieldtom.cool/resource/libs/echarts/5.5.0/echarts.min.js"></script>
 <script>

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -48,28 +48,26 @@ include 'menu.php';
                         <p class="text-sm mb-3" style="color: var(--booadmin-muted);"><?php _e('以下插件为 BooAdmin 配套插件，可增强后台安全与功能体验。'); ?></p>
                         <div class="space-y-2">
                             <?php if (!$hasPasskey): ?>
-                            <div class="flex items-center justify-between p-3 border" style="background-color: var(--booadmin-surface); border-color: var(--booadmin-border);">
-                                <div>
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between p-3 border gap-3" style="background-color: var(--booadmin-surface); border-color: var(--booadmin-border);">
+                                <div class="flex-1 min-w-0">
                                     <span class="font-medium" style="color: var(--booadmin-text);">Passkey</span>
-                                    <span class="text-xs ml-2" style="color: var(--booadmin-info);"><?php _e('通行密钥登录插件，完全开源，且符合 IEEE 安全标准，支持同一账号的多设备通信秘钥绑定，轻松实现同微软等大厂一致快捷、安全的无密码登录体验。'); ?></span>
+                                    <span class="text-xs ml-2 block sm:inline" style="color: var(--booadmin-info);"><?php _e('通行密钥登录插件，完全开源，且符合 IEEE 安全标准，支持同一账号的多设备通信秘钥绑定，轻松实现同微软等大厂一致快捷、安全的无密码登录体验。'); ?></span>
                                 </div>
-                                <div class="flex gap-2 text-xs">
-                                    <a href="https://cnb.cool/little-gt/Passkey" target="_blank" class="hover:underline" style="color: var(--booadmin-link);"><?php _e('国内下载'); ?></a>
-                                    <span style="color: var(--booadmin-border-strong);">|</span>
-                                    <a href="https://github.com/little-gt/PLUGION-Passkey" target="_blank" class="hover:underline" style="color: var(--booadmin-link);"><?php _e('GitHub'); ?></a>
+                                <div class="flex items-center gap-2 text-xs shrink-0">
+                                    <a href="https://cnb.cool/little-gt/Passkey" target="_blank" class="px-2 py-1 border hover:opacity-80 transition-opacity whitespace-nowrap" style="color: var(--booadmin-link); border-color: var(--booadmin-border); background-color: var(--booadmin-bg);"><?php _e('国内下载'); ?></a>
+                                    <a href="https://github.com/little-gt/PLUGION-Passkey" target="_blank" class="px-2 py-1 border hover:opacity-80 transition-opacity whitespace-nowrap" style="color: var(--booadmin-link); border-color: var(--booadmin-border); background-color: var(--booadmin-bg);"><?php _e('GitHub'); ?></a>
                                 </div>
                             </div>
                             <?php endif; ?>
                             <?php if (!$hasPassport): ?>
-                            <div class="flex items-center justify-between p-3 border" style="background-color: var(--booadmin-surface); border-color: var(--booadmin-border);">
-                                <div>
+                            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between p-3 border gap-3" style="background-color: var(--booadmin-surface); border-color: var(--booadmin-border);">
+                                <div class="flex-1 min-w-0">
                                     <span class="font-medium" style="color: var(--booadmin-text);">Passport</span>
-                                    <span class="text-xs ml-2" style="color: var(--booadmin-info);"><?php _e('账户密码找回插件，完全开源，且支持自定义邮件模版，内置网安标准的行为日志系统，可实现快速、安全的密码找回体验。'); ?></span>
+                                    <span class="text-xs ml-2 block sm:inline" style="color: var(--booadmin-info);"><?php _e('账户密码找回插件，完全开源，且支持自定义邮件模版，内置网安标准的行为日志系统，可实现快速、安全的密码找回体验。'); ?></span>
                                 </div>
-                                <div class="flex gap-2 text-xs">
-                                    <a href="https://cnb.cool/little-gt/Passport" target="_blank" class="hover:underline" style="color: var(--booadmin-link);"><?php _e('国内下载'); ?></a>
-                                    <span style="color: var(--booadmin-border-strong);">|</span>
-                                    <a href="https://github.com/little-gt/PLUGION-Passport" target="_blank" class="hover:underline" style="color: var(--booadmin-link);"><?php _e('GitHub'); ?></a>
+                                <div class="flex items-center gap-2 text-xs shrink-0">
+                                    <a href="https://cnb.cool/little-gt/Passport" target="_blank" class="px-2 py-1 border hover:opacity-80 transition-opacity whitespace-nowrap" style="color: var(--booadmin-link); border-color: var(--booadmin-border); background-color: var(--booadmin-bg);"><?php _e('国内下载'); ?></a>
+                                    <a href="https://github.com/little-gt/PLUGION-Passport" target="_blank" class="px-2 py-1 border hover:opacity-80 transition-opacity whitespace-nowrap" style="color: var(--booadmin-link); border-color: var(--booadmin-border); background-color: var(--booadmin-bg);"><?php _e('GitHub'); ?></a>
                                 </div>
                             </div>
                             <?php endif; ?>


### PR DESCRIPTION
Upgrade BooAdmin to v1.1.18: update README and SECURITY notes and bump displayed version. Update admin assets references (normalize, grid, light/dark, style, nprogress) to v1.1.18 and upgrade Font Awesome CDN to 7.2.0 to restore icon availability. Improve plugin management UI: responsive layout, wrapped info text, and styled download/GitHub buttons for Passkey and Passport. Minor bugfixes and style-related fixes noted in changelog.