### PR TITLE
KaTeX support & preview styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 一款使用 TailwindCSS 精心重构的 Typecho 现代化后台主题。完全支持 Typecho 1.3.0，采用 GARFIELDTOM'S NEST CDN 进行资源加速分发，提供稳定且高效的加载体验。
 
-[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.2.0-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
-[![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)](LICENSE)
+![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.2.1-blue?style=for-the-badge)
+![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)
 ![LTS](https://img.shields.io/badge/Status-LTS%20Stable-blue?style=for-the-badge)
 
 ![登录页面](https://cnb.cool/little-gt/BooAdmin/-/git/raw/main/screenshot/screenshot0.png)
@@ -124,29 +124,16 @@
 
 ---
 
-## 🚀 v1.2.0 版本更新速递
-
-> 感谢提出的关于对主题文件校验的建议，经过实验发现，这个校验做成独立的之后比较麻烦，以及 CDN 等权威资源更新等比较麻烦，考虑到本主题完全开源，且搜索一下 BooAdmin 就可以找到我们的权威仓库的话，就算了吧。
+## 🚀 v1.2.1 版本更新速递
 
 ### 🎨 样式架构
 
-* 重构通知系统框架，统一结构与状态管理逻辑；
-* 重构 NProgress 实现，规范生命周期与触发机制；
-* 修复管理用户、分类页面多选状态显示问题。
+* 优化了撰写文章和撰写独立页面的预览功能的 Markdown 解析器的能力，优化撰写体验；
+* 优化了登录和注册页面的设计，使得更加统一和权重一致。
 
 ### 🛠️ 内核质量
 
-* 系统性清理并整合历史遗留样式，消除不一致与冗余定义；
-* 重构 `table-js` 模块：
-
-  * 对齐 BooAdmin 现代化设计范式；
-  * 移除不稳定的原生依赖逻辑，修复偶发性功能与样式异常；
-* 重构预览功能：
-
-  * 替换历史实现方案；
-  * 解耦旧逻辑，提升可维护性与稳定性；
-* 合并重复样式单元，降低资源体积与加载开销；
-* 重新整理样式文件结构，优化模块划分与引用关系。
+* 升级了 `editor-js` 模块，使得边写边预览功能支持解析 LaTex 公式。
 
 ### 🔧 对 Typecho.js 修正的说明
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 > BooAdmin 是一个完全开源、未压缩加密的 Typecho 后台主题，代码透明可审计。如发现安全问题，您可以根据本安全策略的说明进行处理，并且通知 BooAdmin 的开发者。
 
-[![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.2.0-blue?style=for-the-badge)](https://github.com/little-gt/THEME-BooAdmin/releases)
-[![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)](LICENSE)
+![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.2.1-blue?style=for-the-badge)
+![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)
 
 ---
 
@@ -11,9 +11,9 @@
 
 | 版本 | 状态 | 说明 |
 | :--- | :---: | :--- |
-| **v1.2.0** | ✅ 支持 | 当前主分支，持续接收安全更新 |
-| **v1.1.x 系列** | ❌ EOL | 已完成样式重构，停止维护，请升级至 v1.2.0 及更高 |
-| **v1.0.x 系列** | ❌ EOL | 已抵达生命周期，停止维护，请升级至 v1.2.0 及更高 |
+| **v1.2.1** | ✅ 支持 | 当前主分支，持续接收安全更新 |
+| **v1.1.x 系列** | ❌ EOL | 已完成样式重构，停止维护，请升级至 v1.2.1 及更高 |
+| **v1.0.x 系列** | ❌ EOL | 已抵达生命周期，停止维护，请升级至 v1.2.1 及更高 |
 
 ---
 

--- a/admin/copyright.php
+++ b/admin/copyright.php
@@ -13,7 +13,7 @@
             <div class="booadmin-copyright-popup" id="booadminCopyrightPopup">
                 <button class="close-btn" onclick="closePopup(); event.stopPropagation();">&times;</button>
                 <h3>关于 BooAdmin</h3>
-                <div class="version">版本 1.2.0</div>
+                <div class="version">版本 1.2.1</div>
                 <div class="content">
                     <div class="left">
                         <p class="main-copy"><strong>BooAdmin 是免费开源项目。</strong>BooAdmin 的开源维护、CDN资源分发与新功能更新都离不开您的捐助。您的支持将帮助我覆盖以下成本：</p>

--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -1805,81 +1805,417 @@ body:has(.menu-bar[open]) {
 	height:1px;
 	background-color:var(--booadmin-border)
 }
+/* ========================================
+ * Markdown 预览区域 - #wmd-preview
+ * 参考 preview.php 设计，统一视觉风格
+ * ======================================== */
+
 #wmd-preview {
-	background:var(--booadmin-surface);
-	margin:1em 0;
-	padding:0 15px;
-	word-wrap:break-word;
-	overflow:auto;
-	
+    background: var(--booadmin-surface);
+    margin: 0;
+    padding: 24px 20px 28px;
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+    overflow-x: hidden;
+    overflow-y: auto;
+    line-height: 1.8;
+    font-size: 0.9375rem;
+    color: var(--booadmin-text);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
+
+#wmd-preview > *:first-child {
+    margin-top: 0;
+}
+
+#wmd-preview > *:last-child {
+    margin-bottom: 0;
+}
+
+/* 链接样式 */
+#wmd-preview a {
+    color: var(--booadmin-accent);
+    text-decoration: none;
+    text-underline-offset: 0.18em;
+    transition: color 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
+}
+
+#wmd-preview a:hover {
+    text-decoration: underline;
+}
+
+/* 图片和媒体 */
+#wmd-preview img,
+#wmd-preview svg,
+#wmd-preview video,
+#wmd-preview canvas,
+#wmd-preview iframe {
+    max-width: 100%;
+}
+
 #wmd-preview img {
-	max-width:100%
+    display: block;
+    height: auto;
+    border: 1px solid var(--booadmin-border);
+    background: var(--booadmin-surface-2);
 }
-#wmd-preview code,#wmd-preview pre {
-	padding:2px 4px;
-	background:var(--booadmin-border);
-	font-size:14px
+
+/* 段落和基础元素 */
+#wmd-preview p,
+#wmd-preview ul,
+#wmd-preview ol,
+#wmd-preview blockquote,
+#wmd-preview pre,
+#wmd-preview table,
+#wmd-preview dl,
+#wmd-preview figure,
+#wmd-preview details {
+    margin: 1.2rem 0;
 }
-#wmd-preview code {
-	color:var(--booadmin-danger)
+
+/* 标题样式 */
+#wmd-preview h1,
+#wmd-preview h2,
+#wmd-preview h3,
+#wmd-preview h4,
+#wmd-preview h5,
+#wmd-preview h6 {
+    margin: 2rem 0 0.9rem;
+    color: var(--booadmin-text);
+    line-height: 1.28;
+    font-weight: 800;
+    letter-spacing: -0.02em;
 }
-#wmd-preview pre {
-	padding:1em
+
+#wmd-preview h1 {
+    font-size: 1.75rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--booadmin-border);
 }
-#wmd-preview pre code {
-	padding:0;
-	color:var(--booadmin-text)
+
+#wmd-preview h2 {
+    font-size: 1.45rem;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--booadmin-border);
 }
+
+#wmd-preview h3 {
+    font-size: 1.2rem;
+}
+
+#wmd-preview h4 {
+    font-size: 1.08rem;
+}
+
+#wmd-preview h5,
+#wmd-preview h6 {
+    font-size: 1rem;
+}
+
+/* 列表样式 */
+#wmd-preview ul,
+#wmd-preview ol {
+    padding-left: 1.5rem;
+}
+
+#wmd-preview li + li {
+    margin-top: 0.45rem;
+}
+
+#wmd-preview li > ul,
+#wmd-preview li > ol {
+    margin-top: 0.55rem;
+    margin-bottom: 0.55rem;
+}
+
+/* 引用块 */
 #wmd-preview blockquote {
-	margin:1em 1.5em;
-	padding-left:1.5em;
-	border-left:4px solid var(--booadmin-surface-2);
-	color:var(--booadmin-muted)
+    padding: 1rem 1.1rem;
+    border-left: 4px solid var(--booadmin-accent);
+    background: var(--booadmin-surface-2);
+    color: var(--booadmin-muted);
+    margin: 1.2rem 0;
 }
-#wmd-preview hr {
-	margin:2em auto;
-	width:100px;
-	border:1px solid var(--booadmin-surface-2);
-	border-width:2px 0 0 0
+
+#wmd-preview blockquote > *:first-child {
+    margin-top: 0;
 }
-#wmd-preview .summary:after {
-	display:block;
-	margin:2em 0;
-	background:var(--booadmin-highlight-warm);
-	color:var(--booadmin-warning);
-	font-size:.85714em;
-	text-align:center;
-	content:"- more -"
+
+#wmd-preview blockquote > *:last-child {
+    margin-bottom: 0;
 }
-#wmd-preview .embed {
-	border:1px solid var(--booadmin-border);
-	height:40px;
-	overflow:hidden;
-	line-height:40px;
-	text-align:center;
-	font-size:12px;
-	color:var(--booadmin-muted)
+
+#wmd-preview blockquote blockquote {
+    margin: 0.9rem 0 0;
+    background: transparent;
+    border-left-color: var(--booadmin-border-strong);
 }
+
+/* 代码样式 */
+#wmd-preview code,
+#wmd-preview kbd,
+#wmd-preview samp {
+    font-family: "Cascadia Code", Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-size: 0.9em;
+}
+
+#wmd-preview code {
+    padding: 0.18rem 0.42rem;
+    background: var(--booadmin-surface-muted);
+    color: var(--booadmin-text);
+    border: 1px solid var(--booadmin-border);
+    border-radius: 0;
+}
+
+#wmd-preview pre {
+    padding: 16px 18px;
+    overflow-x: auto;
+    background: var(--booadmin-surface-2);
+    color: var(--booadmin-text);
+    border: 1px solid var(--booadmin-border);
+    line-height: 1.7;
+    tab-size: 4;
+    margin: 1.2rem 0;
+    border-radius: 0;
+}
+
+#wmd-preview pre code {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font-size: 0.92rem;
+}
+
+/* 表格样式 */
 #wmd-preview table {
-	width:100%
+    display: block;
+    width: 100%;
+    overflow-x: auto;
+    border-collapse: collapse;
+    border: 1px solid var(--booadmin-border);
+    background: var(--booadmin-surface);
+    margin: 1.2rem 0;
 }
-#wmd-preview table th,#wmd-preview table td {
-	border:1px solid var(--booadmin-border);
-	padding:5px 8px;
-	word-break:break-all
+
+#wmd-preview thead {
+    background: var(--booadmin-table-head);
 }
-#wmd-preview table th {
-	background:var(--booadmin-border)
+
+#wmd-preview th,
+#wmd-preview td {
+    padding: 12px 14px;
+    border: 1px solid var(--booadmin-border);
+    text-align: left;
+    vertical-align: top;
+    white-space: nowrap;
 }
+
+#wmd-preview th {
+    color: var(--booadmin-text);
+    font-weight: 700;
+}
+
+#wmd-preview tbody tr:nth-child(even) {
+    background: var(--booadmin-table-row-even);
+}
+
+#wmd-preview tbody tr:hover {
+    background: var(--booadmin-table-row-hover);
+}
+
+/* 图片和图表容器 */
+#wmd-preview figure {
+    margin-left: 0;
+    margin-right: 0;
+}
+
+#wmd-preview figcaption {
+    margin-top: 0.75rem;
+    color: var(--booadmin-muted);
+    font-size: 0.92rem;
+    text-align: center;
+}
+
+/* 强调文本 */
+#wmd-preview strong {
+    color: var(--booadmin-text);
+    font-weight: 700;
+}
+
+#wmd-preview mark {
+    background: var(--booadmin-highlight-warm);
+    color: inherit;
+    padding: 0.08em 0.22em;
+}
+
+/* 键盘按键 */
+#wmd-preview kbd {
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.7rem;
+    padding: 0 0.45rem;
+    border: 1px solid var(--booadmin-border-strong);
+    background: var(--booadmin-surface);
+    color: var(--booadmin-text);
+    box-shadow: none;
+    border-radius: 0;
+}
+
+/* 缩写 */
+#wmd-preview abbr[title] {
+    text-decoration-style: dotted;
+    cursor: help;
+}
+
+/* 定义列表 */
+#wmd-preview dl dt {
+    margin-top: 1rem;
+    font-weight: 700;
+    color: var(--booadmin-text);
+}
+
+#wmd-preview dl dd {
+    margin: 0.35rem 0 0 1.25rem;
+    color: var(--booadmin-muted);
+}
+
+/* 详情/摘要 */
+#wmd-preview details {
+    border: 1px solid var(--booadmin-border);
+    background: var(--booadmin-surface-2);
+    border-radius: 0;
+}
+
+#wmd-preview summary {
+    cursor: pointer;
+    padding: 0.9rem 1rem;
+    font-weight: 600;
+    color: var(--booadmin-text);
+}
+
+#wmd-preview details > :not(summary) {
+    padding: 0 1rem 1rem;
+}
+
+/* 复选框和任务列表 */
+#wmd-preview input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    margin-right: 0.45rem;
+    accent-color: var(--booadmin-accent);
+    vertical-align: -0.12rem;
+}
+
+#wmd-preview .contains-task-list,
+#wmd-preview .task-list {
+    list-style: none;
+    padding-left: 0;
+}
+
+#wmd-preview .contains-task-list li,
+#wmd-preview .task-list li {
+    padding-left: 0.15rem;
+}
+
+/* 分割线 */
+#wmd-preview hr {
+    margin: 2rem 0;
+    border: 0;
+    border-top: 1px solid var(--booadmin-border);
+}
+
+/* iframe 和视频 */
+#wmd-preview iframe,
+#wmd-preview video {
+    display: block;
+    width: 100%;
+    min-height: 360px;
+    border: 1px solid var(--booadmin-border);
+    background: var(--booadmin-surface-2);
+}
+
+/* 表格包裹器 */
+#wmd-preview .table-wrap {
+    margin: 1.2rem 0;
+    overflow-x: auto;
+}
+
+#wmd-preview .table-wrap table {
+    margin: 0;
+}
+
+/* 摘要分割线 (<!--more-->) */
+#wmd-preview .summary:after {
+    display: block;
+    margin: 2em 0;
+    background: var(--booadmin-highlight-warm);
+    color: var(--booadmin-warning);
+    font-size: .85714em;
+    text-align: center;
+    content: "- more -";
+    padding: 0.5rem 1rem;
+    border-radius: 0;
+}
+
+/* 嵌入内容占位符 */
+#wmd-preview .embed {
+    border: 1px solid var(--booadmin-border);
+    height: 40px;
+    overflow: hidden;
+    line-height: 40px;
+    text-align: center;
+    font-size: 12px;
+    color: var(--booadmin-muted);
+    background: var(--booadmin-surface-2);
+    padding: 0 1rem;
+}
+
+/* KaTeX 数学公式样式 */
+#wmd-preview .katex {
+    font-size: 1.02em;
+}
+
+#wmd-preview .katex-display {
+    margin: 1.5rem 0;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 0.2rem 0.1rem;
+}
+
+/* 脚注样式 */
+#wmd-preview .footnotes {
+    margin-top: 2.4rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid var(--booadmin-border);
+    color: var(--booadmin-muted);
+    font-size: 0.94rem;
+}
+
+#wmd-preview .footnotes hr {
+    display: none;
+}
+
+#wmd-preview .footnote-ref,
+#wmd-preview .footnote-backref {
+    color: var(--booadmin-accent);
+    text-decoration: none;
+}
+
+/* 行内元素 */
 #wmd-preview span.line {
-	display:inline;
-	height:1px;
-	line-height:1px;
-	position:absolute
+    display: inline;
+    height: 1px;
+    line-height: 1px;
+    position: absolute;
 }
-#wmd-preview .focus,#wmd-preview .focus * {
-	background-color:var(--booadmin-highlight-warm) !important
+
+/* 焦点状态 */
+#wmd-preview .focus,
+#wmd-preview .focus * {
+    background-color: var(--booadmin-highlight-warm) !important;
 }
 @keyframes fullscreen-upload {
 	0% {
@@ -1910,14 +2246,16 @@ body:has(.menu-bar[open]) {
 	outline:none
 }
 .fullscreen #wmd-preview {
-	top:53px;
-	right:0;
-	margin:0;
-	padding:5px 20px;
-	border:none;
-	border-left:1px solid var(--booadmin-surface-2);
-	background:var(--booadmin-bg);
-	overflow:auto
+    top: 53px;
+    right: 0;
+    margin: 0;
+    padding: 20px 24px;
+    border: none;
+    border-left: 1px solid var(--booadmin-border);
+    background: var(--booadmin-bg);
+    overflow-x: hidden;
+    overflow-y: auto;
+    line-height: 1.8;
 }
 .fullscreen .submit {
 	right:0;
@@ -3716,6 +4054,49 @@ button:not(.view-toggle button),.btn:not(.view-toggle button),a.btn {
 
 .booadmin-copyright-popup .action a.secondary:hover {
 	background-color:var(--booadmin-border-strong);
+}
+
+/* ========================================
+ * Markdown 预览区域 - 响应式优化
+ * ======================================== */
+
+@media (max-width: 720px) {
+    #wmd-preview {
+        padding: 16px 14px 20px;
+        font-size: 0.875rem;
+    }
+
+    #wmd-preview h1 {
+        font-size: 1.5rem;
+    }
+
+    #wmd-preview h2 {
+        font-size: 1.25rem;
+    }
+
+    #wmd-preview h3 {
+        font-size: 1.1rem;
+    }
+
+    #wmd-preview pre {
+        padding: 12px 14px;
+        font-size: 0.85rem;
+    }
+
+    #wmd-preview table th,
+    #wmd-preview table td {
+        padding: 8px 10px;
+        font-size: 0.85rem;
+    }
+
+    #wmd-preview iframe,
+    #wmd-preview video {
+        min-height: 220px;
+    }
+
+    #wmd-preview blockquote {
+        padding: 0.85rem 0.95rem;
+    }
 }
 
 @media (max-width: 768px) {

--- a/admin/editor-js.php
+++ b/admin/editor-js.php
@@ -31,6 +31,12 @@
 <script src="<?php $options->adminStaticUrl('js', 'hyperdown.js'); ?>"></script>
 <script src="<?php $options->adminStaticUrl('js', 'pagedown.js'); ?>"></script>
 <script src="<?php $options->adminStaticUrl('js', 'purify.js'); ?>"></script>
+
+<!-- KaTeX Resources -->
+<link rel="stylesheet" href="https://cdn.garfieldtom.cool/resource/libs/KaTeX/0.16.38/katex.min.css">
+<script src="https://cdn.garfieldtom.cool/resource/libs/KaTeX/0.16.38/katex.min.js"></script>
+<script src="https://cdn.garfieldtom.cool/resource/libs/KaTeX/0.16.38/contrib/auto-render.min.js"></script>
+
 <script>
 $(document).ready(function () {
     const textarea = $('#text'),
@@ -128,12 +134,30 @@ $(document).ready(function () {
         let count = images.length;
 
         if (count === 0) {
+            renderMathInElement(preview[0], {
+                delimiters: [
+                    { left: "$$", right: "$$", display: true },
+                    { left: "$", right: "$", display: false },
+                    { left: "\\(", right: "\\)", display: false },
+                    { left: "\\[", right: "\\]", display: true }
+                ],
+                throwOnError: false
+            });
             reloadScroll(true);
         } else {
             images.bind('load error', function () {
                 count --;
 
                 if (count === 0) {
+                    renderMathInElement(preview[0], {
+                        delimiters: [
+                            { left: "$$", right: "$$", display: true },
+                            { left: "$", right: "$", display: false },
+                            { left: "\\(", right: "\\)", display: false },
+                            { left: "\\[", right: "\\]", display: true }
+                        ],
+                        throwOnError: false
+                    });
                     reloadScroll(true);
                 }
             });
@@ -253,13 +277,26 @@ $(document).ready(function () {
             $(".wmd-edittab a").removeClass('active');
             $(this).addClass("active");
             $("#wmd-editarea, #wmd-preview").addClass("wmd-hidetab");
-            
+
             const selected_tab = $(this).attr("href"),
                 selected_el = $(selected_tab).removeClass("wmd-hidetab");
 
             // 预览时隐藏编辑器按钮
             if (selected_tab === "#wmd-preview") {
                 $("#wmd-button-row").addClass("wmd-visualhide");
+
+                // 确保预览时 LaTeX 公式已渲染
+                if (typeof renderMathInElement === 'function') {
+                    renderMathInElement(preview[0], {
+                        delimiters: [
+                            { left: "$$", right: "$$", display: true },
+                            { left: "$", right: "$", display: false },
+                            { left: "\\(", right: "\\)", display: false },
+                            { left: "\\[", right: "\\]", display: true }
+                        ],
+                        throwOnError: false
+                    });
+                }
             } else {
                 $("#wmd-button-row").removeClass("wmd-visualhide");
             }

--- a/admin/header.php
+++ b/admin/header.php
@@ -5,14 +5,14 @@ if (!defined('__TYPECHO_ADMIN__')) {
 
 $header = '
 <!-- CSS Reset & Grid -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'normalize.css?v=1.2.0', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'grid.css?v=1.2.0', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'normalize.css?v=1.2.1', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'grid.css?v=1.2.1', true) . '">
 <!-- Theme Variables -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'light.css?v=1.2.0c', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'dark.css?v=1.2.0c', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'light.css?v=1.2.1', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'dark.css?v=1.2.1', true) . '">
 <!-- Component Styles -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'style.css?v=1.2.0c', true) . '">
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'nprogress.css?v=1.2.0c', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'style.css?v=1.2.1', true) . '">
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'nprogress.css?v=1.2.1', true) . '">
 <!-- NProgress -->
 <script src="' . $options->adminStaticUrl('js', 'nprogress.js', true) . '"></script>
 <!-- TailwindCSS -->

--- a/admin/login.php
+++ b/admin/login.php
@@ -23,11 +23,11 @@ include 'header.php';
     <div class="hidden md:flex md:w-1/2 flex-col justify-center items-center bg-cover bg-center relative" style="background-image: url('https://cdn.garfieldtom.cool/img/wldairy/poster/horizontal/%E9%81%87%E8%A7%81%E4%BD%A0%E7%9A%84%E7%8C%AB_%E9%82%A3%E4%B8%80%E5%A4%A9.jpg');">
         <div class="absolute inset-0 pointer-events-none" style="background-color: var(--booadmin-hero-overlay);"></div>
         <div class="relative z-10 text-white p-12 text-center">
-            <h1 class="text-4xl font-bold mb-4"><?php _e('BooAdmin'); ?></h1>
-            <p class="text-lg opacity-90"><?php _e('一个现代化、简洁且强大的 Typecho 后台主题'); ?></p>
+            <h1 class="text-4xl font-bold mb-4"><?php $options->title(); ?></h1>
+            <p class="text-lg opacity-90"><?php $options->description(); ?></p>
         </div>
         <div class="absolute bottom-6 text-white/50 text-xs">
-            &copy; <?php echo date('Y'); ?> Typecho Team.
+            &copy; <?php echo date('Y'); ?> BooAdmin Team.
         </div>
     </div>
 
@@ -145,13 +145,13 @@ include 'header.php';
                     <div class="w-full border-t border-gray-200"></div>
                 </div>
                 <div class="relative flex justify-center text-sm">
-                    <span class="px-2 bg-white text-gray-500"><?php _e('或者'); ?></span>
+                    <span class="px-2 bg-white text-gray-500"><?php _e('没有账号？'); ?></span>
                 </div>
             </div>
 
             <div class="text-center">
                 <a href="<?php $options->registerUrl(); ?>" class="text-sm font-medium text-discord-accent hover:text-discord-accent/80 hover:underline">
-                    <?php _e('创建一个新账号'); ?>
+                    <?php _e('创建一个账号'); ?>
                 </a>
             </div>
             <?php endif; ?>

--- a/admin/register.php
+++ b/admin/register.php
@@ -18,11 +18,11 @@ include 'header.php';
     <div class="hidden md:flex md:w-1/2 flex-col justify-center items-center bg-cover bg-center relative" style="background-image: url('https://cdn.garfieldtom.cool/img/wldairy/poster/horizontal/%E9%81%87%E8%A7%81%E4%BD%A0%E7%9A%84%E7%8C%AB_%E9%82%A3%E4%B8%80%E5%A4%A9.jpg');">
         <div class="absolute inset-0 pointer-events-none" style="background-color: var(--booadmin-hero-overlay);"></div>
         <div class="relative z-10 text-white p-12 text-center">
-            <h1 class="text-4xl font-bold mb-4"><?php _e('加入我们'); ?></h1>
-            <p class="text-lg opacity-90"><?php _e('开启您的创作之旅，记录生活点滴'); ?></p>
+            <h1 class="text-4xl font-bold mb-4"><?php $options->title(); ?></h1>
+            <p class="text-lg opacity-90"><?php $options->description(); ?></p>
         </div>
         <div class="absolute bottom-6 text-white/50 text-xs">
-            &copy; <?php echo date('Y'); ?> Typecho Team.
+            &copy; <?php echo date('Y'); ?> BooAdmin Team.
         </div>
     </div>
 
@@ -66,7 +66,7 @@ include 'header.php';
 
             <div class="text-center">
                 <a href="<?php $options->adminUrl('login.php'); ?>" class="font-medium text-discord-accent hover:text-discord-accent/80 hover:underline">
-                    <?php _e('直接登录'); ?>
+                    <?php _e('返回直接登录'); ?>
                 </a>
             </div>
         </div>


### PR DESCRIPTION
Integrate KaTeX rendering into the editor preview and significantly enhance the Markdown preview styling. editor-js.php: add KaTeX CSS/JS and call renderMathInElement (with common delimiters and throwOnError:false) when previewing and after images load. admin/css/style.css: large stylesheet additions for #wmd-preview (typography, headings, lists, blockquotes, code, tables, images, embeds, footnotes, keyboard tokens, responsive tweaks and fullscreen adjustments) to unify and improve preview rendering. README.md and SECURITY.md: update badges/changelog to v1.2.1 and adjust release notes. header.php: bump static asset query versions to 1.2.1. Minor UI copy tweaks in admin/login.php and admin/register.php (use site title/description, update copyright and link labels).