### PR TITLE
Improve write-screen layout and preview overflow

### DIFF
--- a/admin/css/style.css
+++ b/admin/css/style.css
@@ -1814,10 +1814,15 @@ body:has(.menu-bar[open]) {
     background: var(--booadmin-surface);
     margin: 0;
     padding: 24px 20px 28px;
+    width: 100%;
+    max-width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     word-wrap: break-word;
     overflow-wrap: anywhere;
     overflow-x: hidden;
     overflow-y: auto;
+    scrollbar-gutter: stable;
     line-height: 1.8;
     font-size: 0.9375rem;
     color: var(--booadmin-text);
@@ -1991,9 +1996,9 @@ body:has(.menu-bar[open]) {
 
 /* 表格样式 */
 #wmd-preview table {
-    display: block;
-    width: 100%;
-    overflow-x: auto;
+    display: table;
+    width: max-content;
+    min-width: 100%;
     border-collapse: collapse;
     border: 1px solid var(--booadmin-border);
     background: var(--booadmin-surface);
@@ -2138,12 +2143,25 @@ body:has(.menu-bar[open]) {
 }
 
 /* 表格包裹器 */
+#wmd-preview .wmd-overflow-wrap,
 #wmd-preview .table-wrap {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     margin: 1.2rem 0;
     overflow-x: auto;
+    overflow-y: hidden;
+    max-width: 100%;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+    scrollbar-gutter: stable;
 }
 
-#wmd-preview .table-wrap table {
+#wmd-preview .wmd-overflow-wrap table,
+#wmd-preview .table-wrap table,
+#wmd-preview .wmd-overflow-wrap pre,
+#wmd-preview .wmd-overflow-wrap .katex-display {
     margin: 0;
 }
 
@@ -2625,6 +2643,7 @@ main {
 	display:flex;
 	flex-direction:column;
 	min-height:100vh;
+	min-width:0;
 	/* Remove overflow restrictions */
 }
 /* Override overflow-hidden class on main */
@@ -2639,8 +2658,39 @@ main > header {
 /* Content area expands to fill space,no internal scroll */
 main > .flex-1.overflow-y-auto,main > div.flex-1 {
 	flex:1 0 auto;
+	min-width:0;
 	overflow:visible !important;
 	/* Override overflow-y-auto,let page scroll */
+}
+/* Write screens: lock horizontal bounds, keep local overflow inside preview wrappers */
+main.write-screen > .flex-1.overflow-y-auto,
+main.write-screen > div.flex-1 {
+	overflow:visible !important;
+	overflow-x:hidden !important;
+	min-width:0;
+}
+main.write-screen .w-full.max-w-none,
+main.write-screen form[name="write_post"],
+main.write-screen form[name="write_page"],
+main.write-screen form[name="write_post"] > .flex-1,
+main.write-screen form[name="write_page"] > .flex-1,
+main.write-screen .editor-container,
+main.write-screen #wmd-editarea,
+main.write-screen #wmd-preview {
+	min-width:0;
+	max-width:100%;
+}
+main.write-screen form[name="write_post"] > .flex-1,
+main.write-screen form[name="write_page"] > .flex-1 {
+	overflow-x:hidden;
+}
+main.write-screen #wmd-preview th,
+main.write-screen #wmd-preview td {
+	white-space:normal;
+	word-break:break-word;
+}
+main.write-screen #wmd-preview td a {
+	word-break:break-all;
 }
 /* Footer follows content naturally */
 #admin-footer {

--- a/admin/editor-js.php
+++ b/admin/editor-js.php
@@ -138,6 +138,33 @@ $(document).ready(function () {
         ],
         throwOnError: false
     };
+
+    function ensurePreviewOverflowContainers() {
+        preview.find('table, pre, .katex-display').each(function () {
+            const target = $(this);
+
+            if (target.parent('.wmd-overflow-wrap').length > 0) {
+                return;
+            }
+
+            if (target.is('table') && target.parent('.table-wrap').length > 0) {
+                return;
+            }
+
+            const wrapper = $('<div class="wmd-overflow-wrap" />');
+
+            if (target.is('table')) {
+                wrapper.addClass('is-table');
+            } else if (target.is('pre')) {
+                wrapper.addClass('is-code');
+            } else {
+                wrapper.addClass('is-math');
+            }
+
+            target.wrap(wrapper);
+        });
+    }
+
     let previewSyncTimer = null;
     function syncPreviewAfterLayout() {
         if (previewSyncTimer) {
@@ -152,6 +179,7 @@ $(document).ready(function () {
                 renderMathInElement(preview[0], mathRenderOptions);
             }
 
+            ensurePreviewOverflowContainers();
             reloadScroll(true);
         }, 30);
     }
@@ -341,9 +369,9 @@ $(document).ready(function () {
             // 重新调整工具栏高度和布局
             adjustToolbarHeight();
 
-            // 预览和编辑窗口高度一致
-            if (!isFullScreen) {
-                $("#wmd-preview").css("height", "");
+            // Auto-size preview height outside fullscreen
+            if (!isFullScreen && selected_tab === "#wmd-preview") {
+                preview.css('height', '');
             }
 
             if (selected_tab === "#wmd-preview") {

--- a/admin/write-page.php
+++ b/admin/write-page.php
@@ -16,7 +16,7 @@ while ($parents->next()) {
     $parentPages[$parents->cid] = str_repeat('&nbsp;&nbsp;&nbsp;&nbsp;', $parents->levels) . $parents->title;
 }
 ?>
-<main class="flex-1 flex flex-col overflow-hidden bg-discord-light">
+<main class="write-screen flex-1 flex flex-col overflow-hidden bg-discord-light">
     <!-- Top Header -->
     <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 z-10">
         <div class="flex items-center text-discord-muted">
@@ -38,11 +38,11 @@ while ($parents->next()) {
     </header>
 
     <!-- Content Area -->
-    <div class="flex-1 overflow-y-auto p-4 md:p-8">
-        <div class="w-full max-w-none mx-auto h-full flex flex-col">
-            <form class="flex flex-col lg:flex-row gap-6 flex-1 min-h-0" action="<?php $security->index('/action/contents-page-edit'); ?>" method="post" name="write_page">
+    <div class="flex-1 min-w-0 overflow-x-hidden overflow-y-auto p-4 md:p-8">
+        <div class="w-full max-w-none min-w-0 mx-auto h-full flex flex-col">
+            <form class="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 min-w-0" action="<?php $security->index('/action/contents-page-edit'); ?>" method="post" name="write_page">
                 <!-- Main Editor Area -->
-                <div class="flex-1 flex flex-col min-h-0 overflow-y-auto lg:overflow-visible">
+                <div class="flex-1 min-w-0 flex flex-col min-h-0 overflow-y-auto lg:overflow-visible">
                     <?php if ($page->draft): ?>
                         <div class="mb-4 bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 text-sm">
                             <?php if ($page->draft['cid'] != $page->cid): ?>
@@ -56,7 +56,7 @@ while ($parents->next()) {
                         </div>
                     <?php endif; ?>
 
-                    <div class="bg-white border border-gray-100 p-6 mb-6">
+                    <div class="bg-white border border-gray-100 p-6 mb-6 min-w-0 overflow-x-hidden">
                         <label for="title" class="sr-only"><?php _e('标题'); ?></label>
                         <input type="text" id="title" name="title" autocomplete="off" value="<?php $page->title(); ?>"
                                placeholder="<?php _e('在此输入标题'); ?>" class="w-full text-2xl font-bold border-none focus:outline-none focus:ring-0 placeholder-gray-300 text-discord-text mb-4 p-0"/>

--- a/admin/write-post.php
+++ b/admin/write-post.php
@@ -5,7 +5,7 @@ include 'menu.php';
 
 $post = \Widget\Contents\Post\Edit::alloc()->prepare();
 ?>
-<main class="flex-1 flex flex-col overflow-hidden bg-discord-light">
+<main class="write-screen flex-1 flex flex-col overflow-hidden bg-discord-light">
     <!-- Top Header -->
     <header class="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 z-10">
         <div class="flex items-center text-discord-muted">
@@ -27,11 +27,11 @@ $post = \Widget\Contents\Post\Edit::alloc()->prepare();
     </header>
 
     <!-- Content Area -->
-    <div class="flex-1 overflow-y-auto p-4 md:p-8">
-        <div class="w-full max-w-none mx-auto h-full flex flex-col">
-             <form class="flex flex-col lg:flex-row gap-6 flex-1 min-h-0" action="<?php $security->index('/action/contents-post-edit'); ?>" method="post" name="write_post">
+    <div class="flex-1 min-w-0 overflow-x-hidden overflow-y-auto p-4 md:p-8">
+        <div class="w-full max-w-none min-w-0 mx-auto h-full flex flex-col">
+             <form class="flex flex-col lg:flex-row gap-6 flex-1 min-h-0 min-w-0" action="<?php $security->index('/action/contents-post-edit'); ?>" method="post" name="write_post">
                 <!-- Main Editor Area -->
-                <div class="flex-1 flex flex-col min-h-0 overflow-y-auto lg:overflow-visible">
+                <div class="flex-1 min-w-0 flex flex-col min-h-0 overflow-y-auto lg:overflow-visible">
                     <?php if ($post->draft): ?>
                         <div class="mb-4 bg-yellow-50 border border-yellow-200 text-yellow-800 px-4 py-3 text-sm">
                             <?php if ($post->draft['cid'] != $post->cid): ?>
@@ -45,7 +45,7 @@ $post = \Widget\Contents\Post\Edit::alloc()->prepare();
                         </div>
                     <?php endif; ?>
 
-                    <div class="bg-white border border-gray-100 p-6 mb-6">
+                    <div class="bg-white border border-gray-100 p-6 mb-6 min-w-0 overflow-x-hidden">
                         <label for="title" class="sr-only"><?php _e('标题'); ?></label>
                         <input type="text" id="title" name="title" autocomplete="off" value="<?php $post->title(); ?>"
                                placeholder="<?php _e('在此输入标题'); ?>" class="w-full text-2xl font-bold border-none focus:outline-none focus:ring-0 placeholder-gray-300 text-discord-text mb-4 p-0"/>


### PR DESCRIPTION
Prevent horizontal overflow and improve preview rendering on write screens. CSS: tighten width constraints (min-width, max-width, box-sizing) and add scrollbar-gutter; change table display to preserve layout while ensuring a min-width of 100%; add .wmd-overflow-wrap wrapper rules and numerous .write-screen-specific rules to contain overflow, normalize word-breaking in preview tables, and make editor/preview elements responsive. JS: add ensurePreviewOverflowContainers() to wrap tables, pre and math blocks with .wmd-overflow-wrap, call it after rendering so large elements get contained, and adjust preview auto-size logic. PHP: mark write pages/posts with the write-screen class and add min-w-0 / overflow-x-hidden / structural tweaks on forms and containers so the new CSS rules apply and local overflow is contained. These changes fix unwanted horizontal scrolling and layout breaks in the editor/preview on narrow viewports.