### PR TITLE
Load Tailwind after theme styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tailwindcss.exe

--- a/admin/header.php
+++ b/admin/header.php
@@ -7,12 +7,12 @@ $header = '
 <!-- CSS Reset & Grid -->
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'normalize.css?v=1.3.1', true) . '">
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'grid.css?v=1.3.1', true) . '">
-<!-- TailwindCSS -->
-<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'tailwind.css?v=1.3.1', true) . '">
 <!-- Theme Variables -->
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'style.css?v=1.3.1', true) . '">
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'light.css?v=1.3.1', true) . '">
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'dark.css?v=1.3.1', true) . '">
+<!-- TailwindCSS -->
+<link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'tailwind.css?v=1.3.1', true) . '">
 <!-- NProgress -->
 <script src="' . $options->adminStaticUrl('js', 'nprogress.js', true) . '"></script>
 <link rel="stylesheet" href="' . $options->adminStaticUrl('css', 'nprogress.css', true) . '">


### PR DESCRIPTION
Reordered admin stylesheet includes so `tailwind.css` is loaded after the theme variable/style files, improving CSS precedence with light/dark theme rules. Also added `tailwindcss.exe` to `.gitignore` to avoid committing the local Tailwind binary.