### PR TITLE
【质量】问询弹窗进行统一；统一注释风格

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 一款使用 TailwindCSS 精心重构的 Typecho 现代化后台主题。完全支持 Typecho 1.3.0，采用 GARFIELDTOM'S NEST CDN 进行资源加速分发，提供稳定且高效的加载体验。
 
-![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.3.1--RC5-blue?style=for-the-badge)
+![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.3.2-blue?style=for-the-badge)
 ![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)
 ![LTS](https://img.shields.io/badge/Status-Stable-blue?style=for-the-badge)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 > BooAdmin 是一个完全开源、未压缩加密的 Typecho 后台主题，代码透明可审计。如发现安全问题，您可以根据本安全策略的说明进行处理，并且通知 BooAdmin 的开发者。
 
-![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.3.1--RC5-blue?style=for-the-badge)
+![BooAdmin](https://img.shields.io/badge/BooAdmin-v1.3.2-blue?style=for-the-badge)
 ![License](https://img.shields.io/badge/License-GPLv3-blue?style=for-the-badge)
 
 ---

--- a/admin/backup.php
+++ b/admin/backup.php
@@ -127,46 +127,27 @@ $backupFiles = \Widget\Backup::alloc()->listFiles();
     <?php include 'copyright.php'; ?>
 </main>
 
-<style>
-/* Custom tab styling logic needs to be handled by JS now as classes changed */
-</style>
-
 <?php
 include 'common-js.php';
 include 'form-js.php';
 ?>
-<!-- Restore Confirm Modal -->
-<div id="restore-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认恢复'); ?></h3>
-        <p class="text-discord-muted mb-6"><?php _e('恢复操作将覆盖所有现有数据, 是否继续?'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-restore" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-restore" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认恢复'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 <script>
     $(document).ready(function() {
-        // Tab switching
+        // 切换标签页
         $('.typecho-option-tabs a').click(function(e) {
             e.preventDefault();
             var targetId = $(this).attr('href');
             
-            // Toggle classes for tabs
+            // 切换标签页对应的 class
             $('.typecho-option-tabs a').removeClass('bg-white text-discord-text').addClass('text-gray-500 hover:text-discord-text');
             $(this).removeClass('text-gray-500 hover:text-discord-text').addClass('bg-white text-discord-text');
             
-            // Toggle content
+            // 切换内容区显示
             $('.tab-content').addClass('hidden');
             $(targetId).removeClass('hidden');
         });
 
-        // File input change
+        // 文件选择框变更
         $('#backup-upload-file').change(function() {
             var fileName = $(this).val().split('\\').pop();
             if (fileName) {
@@ -175,32 +156,22 @@ include 'form-js.php';
             }
         });
 
-        // Restore confirmation modal
+        // 恢复确认
         var restoreForm = null;
         $('#backup-secondary form').submit(function (e) {
             e.preventDefault();
             restoreForm = this;
-            $('#restore-confirm-modal').removeClass('hidden');
-        });
-
-        $('#cancel-restore').click(function () {
-            $('#restore-confirm-modal').addClass('hidden');
-            restoreForm = null;
-        });
-
-        $('#confirm-restore').click(function () {
-            if (restoreForm) {
-                restoreForm.submit();
-            }
-            $('#restore-confirm-modal').addClass('hidden');
-        });
-
-        // Close modal when clicking outside
-        $('#restore-confirm-modal').click(function (e) {
-            if (e.target === this) {
-                $('#restore-confirm-modal').addClass('hidden');
-                restoreForm = null;
-            }
+            BooAdmin.confirm({
+                title: '<?php _e('确认恢复'); ?>',
+                message: '<?php _e('恢复操作将覆盖所有现有数据, 是否继续?'); ?>',
+                confirmText: '<?php _e('确认恢复'); ?>',
+                onConfirm: function () {
+                    if (restoreForm) {
+                        restoreForm.submit();
+                    }
+                }
+            });
+            return false;
         });
     });
 </script>

--- a/admin/common-js.php
+++ b/admin/common-js.php
@@ -2,14 +2,15 @@
 <script src="<?php $options->adminStaticUrl('js', 'jquery.js'); ?>"></script>
 <script src="<?php $options->adminStaticUrl('js', 'jquery-ui.js'); ?>"></script>
 <script src="<?php $options->adminStaticUrl('js', 'typecho.js'); ?>"></script>
+<script src="<?php $options->adminStaticUrl('js', 'booadmin.js'); ?>"></script>
 <script>
     (function () {
         $(document).ready(function() {
             // ========================================
-            // Page Loading Progress Bar
+            // 页面加载进度条
             // ========================================
             (function() {
-                // 确保nprogress元素存在且结构完整
+                // 确保 NProgress 元素存在且结构完整
                 function ensureNProgressStructure() {
                     var $nprogress = $('#nprogress');
                     if ($nprogress.length === 0) {
@@ -39,7 +40,7 @@
                     parent: 'body'
                 });
                 
-                // 初始化spinner
+                // 初始化 spinner
                 var $spinner = ensureNProgressStructure();
                 
                 // 启动进度条（默认加载状态）
@@ -280,7 +281,7 @@
                 });
             }
             
-            // Table scroll indicator
+            // 表格滚动指示
             function updateTableScrollIndicator() {
                 $('.table-wrapper[data-table-scroll]').each(function() {
                     var $wrapper = $(this);
@@ -305,16 +306,16 @@
                 });
             }
             
-            // Initialize and bind events
+            // 初始化并绑定事件
             $('.table-wrapper[data-table-scroll]').on('scroll', updateTableScrollIndicator);
             $(window).on('resize', updateTableScrollIndicator);
-            updateTableScrollIndicator(); // Initial check
+            updateTableScrollIndicator(); // 初始检查
 
             // ========================================
-            // Dropdown Menu Enhancement
+            // 下拉菜单增强
             // ========================================
             (function() {
-                // Override dropdownMenu plugin behavior
+                // 覆写 dropdownMenu 插件行为
                 var $doc = $(document);
                 var activeDropdown = null;
                 // 保留原生实现，遇到非 BooAdmin 下拉结构时回退，避免插件按原生方式调用时失效
@@ -350,7 +351,7 @@
                     return { container : $container, btn : $btn, menu : $menu };
                 }
 
-                // Override the dropdownMenu plugin
+                // 覆写 dropdownMenu 插件
                 $.fn.dropdownMenu = function(options) {
                     var useNative = false;
 
@@ -395,7 +396,7 @@
                             
                             var isVisible = $menu.hasClass('is-open');
                             
-                            // Close all other dropdowns first
+                            // 先关闭其它下拉菜单
                             closeOtherDropdowns();
                             
                             if (isVisible) {
@@ -411,7 +412,7 @@
                     });
                 };
 
-                // Close dropdown when clicking outside
+                // 点击外部时关闭下拉菜单
                 $doc.on('click.dropdown', function(e) {
                     if (activeDropdown && !$(e.target).closest(activeDropdown).length) {
                         $('.dropdown-menu').removeClass('is-open').addClass('hidden').attr('aria-hidden', 'true');
@@ -420,21 +421,21 @@
                     }
                 });
 
-                // Close dropdown when clicking on a menu item
+                // 点击菜单项时关闭下拉菜单
                 $doc.on('click.dropdown', '.dropdown-menu a', function() {
                     $('.dropdown-menu').removeClass('is-open').addClass('hidden').attr('aria-hidden', 'true');
                     $('.btn-dropdown-toggle').removeClass('active').attr('aria-expanded', 'false');
                     activeDropdown = null;
                 });
 
-                // Initialize dropdowns on page load
+                // 页面加载时初始化下拉菜单
                 $(function() {
                     $('.btn-dropdown-toggle').each(function() {
                         var $btn = $(this);
                         var $container = $btn.closest('.relative, .group');
                         var $menu = $container.find('.dropdown-menu');
 
-                        // Initialize semantic state for menu visibility.
+                        // 初始化菜单可见性的语义状态
                         $menu.removeClass('is-open').addClass('hidden').attr('aria-hidden', 'true');
                         $btn.attr('aria-expanded', 'false');
                     });
@@ -442,7 +443,7 @@
             })();
 
             // ========================================
-            // View Mode Toggle (Table/Card)
+            // 视图模式切换（表格/卡片）
             // ========================================
             (function() {
                 if ($('.view-toggle').length === 0) {
@@ -467,7 +468,7 @@
                     try {
                         localStorage.setItem(VIEW_MODE_KEY, mode);
                     } catch(e) {
-                        // Ignore localStorage errors
+                        // 忽略 localStorage 错误
                     }
                 }
 
@@ -483,7 +484,7 @@
                     try {
                         localStorage.setItem(VIEW_MODE_USER_SET_KEY, 'true');
                     } catch(e) {
-                        // Ignore localStorage errors
+                        // 忽略 localStorage 错误
                     }
                 }
 
@@ -527,8 +528,8 @@
 
                 initializeViewMode();
 
-                // One-way responsive: auto-switch table→card when screen narrows,
-                // but do NOT auto-switch card→table when screen widens.
+                // 单向响应式：屏幕变窄时自动由表格视图切换为卡片视图，
+                // 但屏幕变宽时不自动切回表格视图。
                 var wasMobile = isMobileViewport();
                 var resizeTimer = null;
                 $(window).on('resize.viewMode', function() {
@@ -538,11 +539,11 @@
 
                     resizeTimer = setTimeout(function() {
                         var isMobile = isMobileViewport();
-                        // Only auto-switch to card view when transitioning from wide to narrow
+                        // 仅当从宽屏过渡到窄屏时，自动切换为卡片视图
                         if (isMobile && !wasMobile) {
                             applyViewMode('card');
                         }
-                        // Do NOT auto-switch back to table when going from narrow to wide
+                        // 从窄屏变回宽屏时不自动切回表格视图
                         wasMobile = isMobile;
                     }, 150);
                 });
@@ -592,4 +593,17 @@
             })();
         });
     })();
+</script>
+<script>
+    // BooAdmin 共享库：注入翻译与通知别名，统一后台前端"体系层"
+    if (window.BooAdmin) {
+        BooAdmin.setI18n({
+            confirmTitle: '<?php _e('操作确认'); ?>',
+            alertTitle: '<?php _e('提示'); ?>',
+            confirm: '<?php _e('确认'); ?>',
+            cancel: '<?php _e('取消'); ?>',
+            ok: '<?php _e('我知道了'); ?>'
+        });
+        BooAdmin.notify = window.TypechoNotification || null;
+    }
 </script>

--- a/admin/copyright.php
+++ b/admin/copyright.php
@@ -13,7 +13,7 @@
             <div class="booadmin-copyright-popup" id="booadminCopyrightPopup">
                 <button class="close-btn" onclick="closePopup(); event.stopPropagation();">&times;</button>
                 <h3>关于 BooAdmin 程序</h3>
-                <div class="version">版本 1.3.1-RC5</div>
+                <div class="version">版本 1.3.2</div>
                 <div class="content">
                     <div class="left">
                         <p class="main-copy"><strong>BooAdmin 是免费开源项目。</strong>BooAdmin 的开源维护、CDN资源分发与新功能更新都离不开您的捐助。您的支持将帮助我覆盖以下成本：</p>
@@ -28,7 +28,7 @@
                     </div>
                     <div class="right">
                         <div class="donation-card">
-                            <img src="<?php $options->adminUrl('img/supportme.png',true); ?>" alt="支持 BooAdmin 开源维护" />
+                            <img src="<?php $options->adminUrl('img/supportme.png'); ?>" alt="支持 BooAdmin 开源维护" />
                         </div>
                     </div>
                 </div>

--- a/admin/custom-fields-js.php
+++ b/admin/custom-fields-js.php
@@ -1,19 +1,4 @@
 <?php if(!defined('__TYPECHO_ADMIN__')) exit; ?>
-<!-- Field Delete Confirm Modal -->
-<div id="field-delete-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认删除'); ?></h3>
-        <p class="text-discord-muted mb-6"><?php _e('确认要删除此字段吗?'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-field-delete" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-field-delete" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认删除'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 <script>
 $(document).ready(function () {
     // 自定义字段
@@ -22,36 +7,25 @@ $(document).ready(function () {
     function attachDeleteEvent (el) {
         $('.btn-delete', el).click(function () {
             fieldToDelete = $(this).closest('.field');
-            $('#field-delete-confirm-modal').removeClass('hidden');
+            BooAdmin.confirm({
+                title: '<?php _e('确认删除'); ?>',
+                message: '<?php _e('确认要删除此字段吗?'); ?>',
+                confirmText: '<?php _e('确认删除'); ?>',
+                onConfirm: function () {
+                    if (fieldToDelete) {
+                        fieldToDelete.fadeOut(function () {
+                            $(this).remove();
+                        });
+                        fieldToDelete = null;
+                    }
+                }
+            });
+            return false;
         });
     }
 
     $('#custom-field .fields .field').each(function () {
         attachDeleteEvent(this);
-    });
-
-    // Field delete modal handlers
-    $('#cancel-field-delete').click(function () {
-        $('#field-delete-confirm-modal').addClass('hidden');
-        fieldToDelete = null;
-    });
-
-    $('#confirm-field-delete').click(function () {
-        if (fieldToDelete) {
-            fieldToDelete.fadeOut(function () {
-                $(this).remove();
-            });
-        }
-        $('#field-delete-confirm-modal').addClass('hidden');
-        fieldToDelete = null;
-    });
-
-    // Close modal when clicking outside
-    $('#field-delete-confirm-modal').click(function (e) {
-        if (e.target === this) {
-            $('#field-delete-confirm-modal').addClass('hidden');
-            fieldToDelete = null;
-        }
     });
 
     $('#custom-field button.operate-add').click(function () {

--- a/admin/editor-js.php
+++ b/admin/editor-js.php
@@ -388,7 +388,7 @@ $(document).ready(function () {
             // 重新调整工具栏高度和布局
             adjustToolbarHeight();
 
-            // Auto-size preview height outside fullscreen
+            // 全屏外自动调整预览高度
             if (!isFullScreen && selected_tab === "#wmd-preview") {
                 preview.css('height', '');
             }

--- a/admin/file-upload-js.php
+++ b/admin/file-upload-js.php
@@ -229,87 +229,66 @@ $(document).ready(function() {
 
     // 显示图片预览模态框
     function showImagePreview(url, title, callback) {
-        // 移除已存在的预览模态框
-        $('#image-preview-modal').remove();
-        
-        // 创建预览模态框
-        var previewModal = $('<div id="image-preview-modal" class="fixed inset-0 bg-black bg-opacity-75 z-50 flex items-center justify-center p-4"></div>')
-            .appendTo('body')
-            .click(function(e) {
-                if ($(e.target).is('#image-preview-modal')) {
-                    previewModal.remove();
-                }
-            });
-        
-        var modalContent = $('<div class="bg-white max-w-4xl w-full max-h-[90vh] flex flex-col shadow-xl"></div>')
-            .appendTo(previewModal);
-        
-        // 模态框头部
-        var modalHeader = $('<div class="px-6 py-4 border-b border-gray-200 flex items-center justify-between"></div>')
-            .appendTo(modalContent);
-        
-        $('<h3 class="text-lg font-bold text-discord-text"><?php _e('图片预览'); ?></h3>')
-            .appendTo(modalHeader);
-        
-        $('<button class="text-gray-400 hover:text-gray-600 transition-colors" title="<?php _e('关闭'); ?>"><i class="fas fa-times"></i></button>')
-            .click(function() {
-                previewModal.remove();
-            })
-            .appendTo(modalHeader);
-        
-        // 模态框内容
-        var modalBody = $('<div class="flex-1 flex items-center justify-center p-6 overflow-auto bg-gray-50"></div>')
-            .appendTo(modalContent);
-        
-        $('<img src="' + url + '" class="max-w-full max-h-[60vh] object-contain shadow-sm" alt="' + title + '">')
-            .appendTo(modalBody);
-        
-        // 模态框底部
-        var modalFooter = $('<div class="px-6 py-4 border-t border-gray-200 bg-white"></div>')
-            .appendTo(modalContent);
-        
-        var footerContent = $('<div class="flex items-center justify-between"></div>')
-            .appendTo(modalFooter);
-        
-        // 图片URL显示框
-        var urlContainer = $('<div class="flex-1 mr-4"></div>')
-            .appendTo(footerContent);
-        
-        $('<input type="text" value="' + url + '" class="w-full px-3 py-2 bg-gray-100 border border-gray-300 text-sm text-gray-800 focus:outline-none" readonly>')
-            .appendTo(urlContainer);
-        
-        // 按钮组
-        var buttonContainer = $('<div class="flex space-x-3"></div>')
-            .appendTo(footerContent);
-        
-        $('<button class="px-4 py-2 bg-gray-200 text-discord-text hover:bg-gray-300 transition-colors text-sm font-medium"><?php _e('取消'); ?></button>')
-            .click(function() {
-                previewModal.remove();
-            })
-            .appendTo(buttonContainer);
-        
-        $('<button class="px-4 py-2 bg-discord-accent text-white hover:bg-blue-600 transition-colors text-sm font-medium"><?php _e('插入图片'); ?></button>')
-            .click(function() {
-                previewModal.remove();
-                callback();
-            })
-            .appendTo(buttonContainer);
+        var bodyHtml =
+            '<div class="flex-1 flex items-center justify-center p-6 overflow-auto bg-gray-50">' +
+                '<img src="' + url + '" class="max-w-full max-h-[60vh] object-contain shadow-sm" alt="' + title + '">' +
+            '</div>' +
+            '<div class="px-6 py-4 border-t border-gray-200 bg-white flex items-center justify-between">' +
+                '<div class="flex-1 mr-4">' +
+                    '<input type="text" value="' + url + '" class="w-full px-3 py-2 bg-gray-100 border border-gray-300 text-sm text-gray-800 focus:outline-none" readonly>' +
+                '</div>' +
+            '</div>';
+
+        BooAdmin.Modal.create({
+            title: '<?php _e('图片预览'); ?>',
+            message: bodyHtml,
+            size: 'md',
+            confirmText: '<?php _e('插入图片'); ?>',
+            cancelText: '<?php _e('取消'); ?>',
+            onConfirm: callback
+        }).open();
     }
 
-    // File delete confirmation modal
-    var fileDeleteData = null;
-    var fileDeleteEl = null;
-
+    // 文件删除确认
     function attachDeleteEvent (el) {
         var file = $('a.insert', el).text();
         $('.delete', el).click(function () {
-            fileDeleteEl = el;
-            fileDeleteData = {
-                cid: $(this).parents('li').data('cid'),
-                file: file
-            };
-            $('#file-delete-confirm-message').text('<?php _e('确认要删除文件 %s 吗?'); ?>'.replace('%s', file));
-            $('#file-delete-confirm-modal').removeClass('hidden');
+            var cid = $(this).parents('li').data('cid');
+            var $deleteEl = $(el);
+
+            var modal = BooAdmin.confirm({
+                title: '<?php _e('确认删除'); ?>',
+                message: '<?php _e('确认要删除文件 %s 吗?'); ?>'.replace('%s', file),
+                confirmText: '<?php _e('确认删除'); ?>',
+                onConfirm: function () {
+                    $.post('<?php $security->index('/action/contents-attachment-edit'); ?>',
+                        {'do' : 'delete', 'cid' : cid},
+                        function (response) {
+                            if (response && response.success !== false) {
+                                if (window.TypechoNotification) {
+                                    TypechoNotification.success('<?php _e('文件已删除'); ?>');
+                                }
+                                $deleteEl.fadeOut(function () {
+                                    $(this).remove();
+                                    updateAttachmentNumber();
+                                });
+                            } else {
+                                if (window.TypechoNotification) {
+                                    TypechoNotification.error(response.message || '<?php _e('删除失败，请重试'); ?>');
+                                }
+                            }
+                            modal.close();
+                        },
+                        'json'
+                    ).fail(function() {
+                        if (window.TypechoNotification) {
+                            TypechoNotification.error('<?php _e('网络错误，删除失败'); ?>');
+                        }
+                        modal.close();
+                    });
+                    return false; // 请求完成前保持弹窗打开
+                }
+            });
             return false;
         });
     }
@@ -318,91 +297,6 @@ $(document).ready(function() {
         attachInsertEvent(this);
         attachDeleteEvent(this);
     });
-
-    // File delete modal handlers
-    $('#cancel-file-delete').click(function () {
-        $('#file-delete-confirm-modal').addClass('hidden');
-        fileDeleteData = null;
-        fileDeleteEl = null;
-    });
-
-    $('#confirm-file-delete').click(function () {
-        if (fileDeleteData && fileDeleteEl) {
-            var $modal = $('#file-delete-confirm-modal');
-            var $confirmBtn = $('#confirm-file-delete');
-            // 在发起请求前快照目标, 避免异步回调期间被关闭/重开逻辑清空或改写
-            var deleteCid = fileDeleteData.cid;
-            var $deleteEl = $(fileDeleteEl);
-            
-            // 禁用按钮防止重复点击
-            $confirmBtn.prop('disabled', true).addClass('opacity-50');
-            
-            $.post('<?php $security->index('/action/contents-attachment-edit'); ?>',
-                {'do' : 'delete', 'cid' : deleteCid},
-                function (response) {
-                    if (response && response.success !== false) {
-                        // 显示成功通知
-                        if (window.TypechoNotification) {
-                            TypechoNotification.success('<?php _e('文件已删除'); ?>');
-                        }
-                        
-                        // 移除文件项
-                        $deleteEl.fadeOut(function () {
-                            $(this).remove();
-                            updateAttachmentNumber();
-                        });
-                        
-                        // 恢复按钮状态
-                        $confirmBtn.prop('disabled', false).removeClass('opacity-50');
-                        
-                        // 关闭模态框并重置状态
-                        $modal.addClass('hidden');
-                        fileDeleteData = null;
-                        fileDeleteEl = null;
-                    } else {
-                        // 显示错误通知
-                        if (window.TypechoNotification) {
-                            TypechoNotification.error(response.message || '<?php _e('删除失败，请重试'); ?>');
-                        }
-                        $confirmBtn.prop('disabled', false).removeClass('opacity-50');
-                    }
-                },
-                'json'
-            ).fail(function() {
-                // 网络错误
-                if (window.TypechoNotification) {
-                    TypechoNotification.error('<?php _e('网络错误，删除失败'); ?>');
-                }
-                $confirmBtn.prop('disabled', false).removeClass('opacity-50');
-            });
-        } else {
-            $('#file-delete-confirm-modal').addClass('hidden');
-        }
-    });
-
-    // Close modal when clicking outside
-    $('#file-delete-confirm-modal').click(function (e) {
-        if (e.target === this) {
-            $('#file-delete-confirm-modal').addClass('hidden');
-            fileDeleteData = null;
-            fileDeleteEl = null;
-        }
-    });
 });
 </script>
-<!-- File Delete Confirm Modal -->
-<div id="file-delete-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认删除'); ?></h3>
-        <p id="file-delete-confirm-message" class="text-discord-muted mb-6"></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-file-delete" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-file-delete" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认删除'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 

--- a/admin/form-js.php
+++ b/admin/form-js.php
@@ -39,7 +39,7 @@
                     const urlObj = new URL(url);
                     input.val(urlObj.toString());
                 } catch {
-                    // ignore
+                    // 忽略
                 }
             }
 

--- a/admin/header.php
+++ b/admin/header.php
@@ -5,14 +5,14 @@ if (!defined('__TYPECHO_ADMIN__')) {
 
 $header = '
 <!-- CSS Reset & Grid -->
-<link rel="stylesheet" href="' . $options->adminUrl('css/normalize.css?v=1.3.1-RC5',true) . '">
-<link rel="stylesheet" href="' . $options->adminUrl('css/grid.css?v=1.3.1-RC5',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/normalize.css?v=1.3.2',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/grid.css?v=1.3.2',true) . '">
 <!-- Theme Variables -->
-<link rel="stylesheet" href="' . $options->adminUrl('css/style.css?v=1.3.1-RC5',true) . '">
-<link rel="stylesheet" href="' . $options->adminUrl('css/light.css?v=1.3.1-RC5',true) . '">
-<link rel="stylesheet" href="' . $options->adminUrl('css/dark.css?v=1.3.1-RC5',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/style.css?v=1.3.2',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/light.css?v=1.3.2',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/dark.css?v=1.3.2',true) . '">
 <!-- TailwindCSS -->
-<link rel="stylesheet" href="' . $options->adminUrl('css/tailwind.css?v=1.3.1-RC5',true) . '">
+<link rel="stylesheet" href="' . $options->adminUrl('css/tailwind.css?v=1.3.2',true) . '">
 <!-- NProgress -->
 <script src="' . $options->adminUrl('js/nprogress.js',true) . '"></script>
 <link rel="stylesheet" href="' . $options->adminUrl('css/nprogress.css',true) . '">

--- a/admin/index.php
+++ b/admin/index.php
@@ -295,7 +295,7 @@ include 'common-js.php';
 ?>
 <script>
     $(document).ready(function () {
-        // Activity Chart Config - 使用真实数据
+        // 活动图表配置（使用真实数据）
         var chartDays = <?php echo $chartDays; ?>;
         var chartPosts = <?php echo $chartPosts; ?>;
         var chartComments = <?php echo $chartComments; ?>;
@@ -386,7 +386,7 @@ include 'common-js.php';
             ]
         };
 
-        // Distribution Chart Config
+        // 分布图表配置
         var distributionOption = {
              tooltip: { trigger: 'item' },
              legend: { bottom: '0%', left: 'center', icon: 'circle' },
@@ -422,7 +422,7 @@ include 'common-js.php';
         var distributionChart = echarts.init(document.getElementById('distribution-chart'));
         distributionChart.setOption(distributionOption);
 
-        // Resize charts on window resize
+        // 窗口尺寸变化时重绘图表
         window.addEventListener('resize', function() {
             activityChart.resize();
             distributionChart.resize();

--- a/admin/js/booadmin.js
+++ b/admin/js/booadmin.js
@@ -1,0 +1,228 @@
+/**
+ * BooAdmin 前端共享库
+ * --------------------------------------------------------------------------
+ * 作为后台 JavaScript 的"体系层"，沉淀跨页面复用的通用能力，避免各 PHP 内联脚本
+ * 重复实现弹窗、确认框等。各页面脚本只需调用统一 API（BooAdmin.confirm / alert /
+ * Modal.create），彼此保持独立、解耦。
+ *
+ * 依赖：jQuery（需在引入本文件之前加载）。
+ *
+ * @version 1.3.1-RC5
+ */
+(function ($, window, document) {
+    'use strict';
+
+    /** 多语言文案，可由 common-js.php 通过 BooAdmin.setI18n 注入翻译 */
+    var i18n = {
+        confirmTitle: '操作确认',
+        alertTitle: '提示',
+        confirm: '确认',
+        cancel: '取消',
+        ok: '我知道了'
+    };
+
+    function setI18n(map) {
+        if (map && typeof map === 'object') {
+            $.extend(i18n, map);
+        }
+    }
+
+    /**
+     * 创建一个模态框控制器。
+     *
+     * @param {Object} options
+     *   id        指定已存在 DOM 的 id 则复用，否则动态创建并追加到 body
+     *   title     标题文本
+     *   message   正文（允许 HTML）
+     *   size      '' | 'sm' | 'md'（默认 sm）
+     *   showCancel 是否显示取消按钮（默认 true）
+     *   confirmText 确认按钮文案
+     *   cancelText  取消按钮文案
+     *   onConfirm  点击确认回调，返回 false 可阻止关闭
+     *   onCancel   点击取消回调
+     *   onClose    任意方式关闭后的回调
+     * @returns {{open:Function, close:Function, el:jQuery, setTitle:Function, setMessage:Function}}
+     */
+    function createModal(options) {
+        options = $.extend({
+            id: '',
+            title: '',
+            message: '',
+            size: 'sm',
+            showCancel: true,
+            confirmText: '',
+            cancelText: '',
+            onConfirm: null,
+            onCancel: null,
+            onClose: null
+        }, options);
+
+        var uid = 'bm' + (createModal._seq = (createModal._seq || 0) + 1);
+        var dynamic = !options.id;
+        var $modal;
+
+        if (options.id) {
+            $modal = $('#' + options.id);
+        }
+
+        if (!$modal || !$modal.length) {
+            var sizeClass = options.size === 'sm' ? ' booadmin-dialog-sm'
+                : options.size === 'md' ? ' booadmin-dialog-md'
+                : options.size === 'lg' ? ' booadmin-dialog-lg' : '';
+
+            $modal = $(
+                '<div class="booadmin-modal hidden" role="dialog" aria-modal="true"' +
+                (options.id ? ' id="' + options.id + '"' : '') + '>' +
+                    '<div class="booadmin-dialog' + sizeClass + '">' +
+                        '<h3 class="booadmin-modal-title text-lg font-bold text-discord-text mb-4"></h3>' +
+                        '<div class="booadmin-modal-message text-discord-muted mb-6"></div>' +
+                        '<div class="flex justify-end space-x-3">' +
+                            '<button type="button" class="booadmin-modal-cancel px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm"></button>' +
+                            '<button type="button" class="booadmin-modal-confirm px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm"></button>' +
+                        '</div>' +
+                    '</div>' +
+                '</div>'
+            ).appendTo('body');
+        }
+
+        var $title = $modal.find('.booadmin-modal-title'),
+            $message = $modal.find('.booadmin-modal-message'),
+            $confirm = $modal.find('.booadmin-modal-confirm'),
+            $cancel = $modal.find('.booadmin-modal-cancel');
+
+        function close() {
+            $modal.addClass('hidden');
+            $(document).off('keydown.' + uid);
+
+            if (dynamic) {
+                $modal.remove();
+            }
+
+            if (typeof options.onClose === 'function') {
+                options.onClose();
+            }
+        }
+
+        function open(override) {
+            override = override || {};
+
+            $title.text(override.title !== undefined ? override.title : (options.title || ''));
+            $message.html(override.message !== undefined ? override.message : (options.message || ''));
+
+            var showCancel = override.showCancel !== undefined ? override.showCancel : options.showCancel;
+            $cancel.toggleClass('hidden', !showCancel);
+            if (showCancel) {
+                $cancel.text(override.cancelText || options.cancelText || i18n.cancel);
+            }
+            $confirm.text(override.confirmText || options.confirmText || i18n.confirm);
+
+            $modal.removeClass('hidden');
+
+            $(document).off('keydown.' + uid).on('keydown.' + uid, function (e) {
+                if (e.key === 'Escape' && !$modal.hasClass('hidden')) {
+                    close();
+                }
+            });
+        }
+
+        // 事件绑定只需一次（按 uid 命名空间隔离，可安全重复调用）
+        $confirm.off('click.' + uid).on('click.' + uid, function () {
+            var keepOpen = typeof options.onConfirm === 'function' && options.onConfirm() === false;
+            if (!keepOpen) {
+                close();
+            }
+        });
+
+        $cancel.off('click.' + uid).on('click.' + uid, function () {
+            close();
+            if (typeof options.onCancel === 'function') {
+                options.onCancel();
+            }
+        });
+
+        $modal.off('click.' + uid).on('click.' + uid, function (e) {
+            if (e.target === this) {
+                close();
+            }
+        });
+
+        return {
+            open: open,
+            close: close,
+            el: $modal,
+            setTitle: function (t) { $title.text(t); },
+            setMessage: function (m) { $message.html(m); }
+        };
+    }
+
+    /* ============================================================
+     * 统一确认 / 提示（基于单例共享模态框，避免 DOM 累积）
+     * ============================================================ */
+    var sharedModal = null;
+    var sharedCallback = null;
+
+    function ensureShared() {
+        if (sharedModal) {
+            return sharedModal;
+        }
+
+        sharedModal = createModal({
+            id: '__booadmin_shared_modal__',
+            onConfirm: function () {
+                var cb = sharedCallback;
+                return typeof cb === 'function' ? cb() : undefined;
+            }
+        });
+
+        return sharedModal;
+    }
+
+    /**
+     * 确认弹窗
+     * @param {Object} opts { title, message, confirmText, cancelText, onConfirm }
+     */
+    function confirm(opts) {
+        opts = opts || {};
+        var m = ensureShared();
+        sharedCallback = typeof opts.onConfirm === 'function' ? opts.onConfirm : null;
+
+        m.open({
+            title: opts.title || i18n.confirmTitle,
+            message: opts.message || '',
+            confirmText: opts.confirmText || i18n.confirm,
+            cancelText: opts.cancelText || i18n.cancel,
+            showCancel: opts.showCancel !== false
+        });
+
+        return m;
+    }
+
+    /**
+     * 提示弹窗（仅一个按钮）
+     * @param {Object} opts { title, message, confirmText, onConfirm }
+     */
+    function alert(opts) {
+        opts = opts || {};
+        var m = ensureShared();
+        sharedCallback = typeof opts.onConfirm === 'function' ? opts.onConfirm : null;
+
+        m.open({
+            title: opts.title || i18n.alertTitle,
+            message: opts.message || '',
+            confirmText: opts.confirmText || i18n.ok,
+            showCancel: false
+        });
+
+        return m;
+    }
+
+    /* ============================================================
+     * 对外 API
+     * ============================================================ */
+    window.BooAdmin = {
+        setI18n: setI18n,
+        Modal: { create: createModal },
+        confirm: confirm,
+        alert: alert
+    };
+})(jQuery, window, document);

--- a/admin/manage-categories.php
+++ b/admin/manage-categories.php
@@ -142,21 +142,6 @@ include 'menu.php';
     <?php include 'copyright.php'; ?>
 </main>
 
-<div id="categories-confirm-modal" class="booadmin-modal hidden" role="dialog" aria-modal="true" aria-labelledby="categories-confirm-modal-title">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 id="categories-confirm-modal-title" class="text-lg font-bold text-discord-text mb-4"><?php _e('操作确认'); ?></h3>
-        <p id="categories-confirm-modal-message" class="text-discord-muted mb-6"><?php _e('请确认是否继续。'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="categories-modal-cancel" type="button" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="categories-modal-confirm" type="button" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认'); ?>
-            </button>
-        </div>
-    </div>
-</div>
-
 <?php
 include 'common-js.php';
 ?>
@@ -165,34 +150,22 @@ include 'common-js.php';
 (function () {
     $(document).ready(function () {
         var form = $('form[name="manage_categories"]'),
-            confirmModal = $('#categories-confirm-modal'),
-            confirmTitle = $('#categories-confirm-modal-title'),
-            confirmMessage = $('#categories-confirm-modal-message'),
-            confirmButton = $('#categories-modal-confirm'),
-            cancelButton = $('#categories-modal-cancel'),
-            pendingSubmit = null,
-            pendingActionEl = null,
             replayingNativeAction = false;
 
         function openModal(title, message, onConfirm, confirmOnly) {
-            confirmTitle.text(title);
-            confirmMessage.text(message);
-            pendingSubmit = onConfirm || null;
-
             if (confirmOnly) {
-                cancelButton.addClass('hidden');
-                confirmButton.text('<?php _e('我知道了'); ?>');
+                BooAdmin.alert({
+                    title: title,
+                    message: message,
+                    confirmText: '<?php _e('我知道了'); ?>'
+                });
             } else {
-                cancelButton.removeClass('hidden');
-                confirmButton.text('<?php _e('确认'); ?>');
+                BooAdmin.confirm({
+                    title: title,
+                    message: message,
+                    onConfirm: onConfirm
+                });
             }
-
-            confirmModal.removeClass('hidden').addClass('flex');
-        }
-
-        function closeModal() {
-            confirmModal.removeClass('flex').addClass('hidden');
-            pendingSubmit = null;
         }
 
         function hasSelectedCategories() {
@@ -239,9 +212,8 @@ include 'common-js.php';
                 return false;
             }
 
-            pendingActionEl = actionLink;
             openModal('<?php _e('操作确认'); ?>', message, function () {
-                var target = pendingActionEl,
+                var target = actionLink,
                     originalLang;
 
                 if (!target || target.length === 0) {
@@ -260,8 +232,6 @@ include 'common-js.php';
                 if (typeof originalLang !== 'undefined') {
                     target.attr('lang', originalLang);
                 }
-
-                pendingActionEl = null;
             }, false);
 
             return false;
@@ -284,30 +254,6 @@ include 'common-js.php';
                 message = btn.data('confirm-message') || btn.attr('lang') || '<?php _e('你确认要执行该操作吗?'); ?>';
 
             requestBatchAction(btn.attr('rel'), message);
-        });
-
-        confirmButton.on('click', function () {
-            var callback = pendingSubmit;
-            closeModal();
-            if (callback) {
-                callback();
-            }
-        });
-
-        cancelButton.on('click', function () {
-            closeModal();
-        });
-
-        confirmModal.on('click', function (e) {
-            if (e.target === this) {
-                closeModal();
-            }
-        });
-
-        $(document).on('keydown', function (e) {
-            if (e.key === 'Escape' && confirmModal.hasClass('flex')) {
-                closeModal();
-            }
         });
 
         // 事件已绑定，解除这些操作链接的原生跳转保护

--- a/admin/manage-comments.php
+++ b/admin/manage-comments.php
@@ -145,7 +145,7 @@ $isAllComments = ('on' == $request->get('__typecho_all_comments') || 'on' == \Ty
                         <tbody class="divide-y divide-gray-100">
                             <?php if($comments->have()): ?>
                                 <?php 
-                                // Store comments data for card view
+                                // 为卡片视图存储评论数据
                                 $commentsData = [];
                                 while($comments->next()): 
                                     $comment = array(
@@ -157,13 +157,13 @@ $isAllComments = ('on' == $request->get('__typecho_all_comments') || 'on' == \Ty
                                         'text'      =>  $comments->text
                                     );
                                     
-                                    // Use getAvatar function for consistent avatar handling
+                                    // 使用 getAvatar 函数统一处理头像
                                     $gravatarHtml = '';
                                     if ('comment' == $comments->type) {
                                         $gravatarHtml = getAvatar($comments->mail, $comments->author, 40);
                                     }
                                     
-                                    // Store data for card view
+                                    // 为卡片视图存储数据
                                     $commentsData[] = [
                                         'coid' => $comments->coid,
                                         'id' => $comments->theId,
@@ -677,7 +677,7 @@ include 'common-js.php';
 include 'table-js.php';
 ?>
 <script type="text/javascript">
-// Global variables for modal state
+// 模态框状态的全局变量
 var currentReplyUrl = '';
 var currentEditUrl = '';
 var currentEditRowId = '';
@@ -685,7 +685,7 @@ var currentEditCardId = '';
 var currentDeleteUrl = '';
 var currentDeleteTarget = null;
 
-// Modal control functions
+// 模态框控制函数
 function showMessageModal(title, content, isConfirm) {
     $('#messageModalTitle').text(title);
     $('#messageModalContent').text(content);
@@ -713,7 +713,7 @@ function openReplyModal(commentData, actionUrl) {
         var authorFirstChar = commentData.author ? commentData.author.charAt(0) : '?';
         var gravatarUrl = '';
         
-        // Try to get gravatar from the row
+        // 尝试从行中获取 gravatar
         var $row = $('#' + commentData.id);
         if ($row.length > 0) {
             var $gravatar = $row.find('td:eq(1) img');
@@ -721,7 +721,7 @@ function openReplyModal(commentData, actionUrl) {
                 gravatarUrl = $gravatar.attr('src');
             }
         }
-        // If not found in table, try card view
+        // 若表格中未找到，则尝试卡片视图
         if (!gravatarUrl) {
             var $card = $('.content-card[data-comment*=\'"author":"' + commentData.author + '"\']').first();
             if ($card.length > 0) {
@@ -883,11 +883,11 @@ function submitEdit() {
 
     $.post(_currentEditUrl, formData, function(o) {
         if (o && o.comment) {
-            // Update table row if exists
+            // 若存在则更新表格行
             if (_currentEditRowId) {
                 var $row = $('#' + _currentEditRowId);
                 if ($row.length > 0) {
-                    // Update data attribute
+                    // 更新 data 属性
                     var oldComment = $row.data('comment');
                     oldComment.author = formData.author;
                     oldComment.mail = formData.mail;
@@ -895,7 +895,7 @@ function submitEdit() {
                     oldComment.text = formData.text;
                     $row.data('comment', oldComment);
                     
-                    // Update author info column
+                    // 更新作者信息列
                     var authorHtml = '<div class="font-medium text-discord-text">'
                         + (formData.url ? '<a target="_blank" href="' + formData.url + '" class="hover:underline">' + formData.author + '</a>' : formData.author)
                         + '</div><div class="text-xs text-gray-400 mt-0.5">';
@@ -912,17 +912,17 @@ function submitEdit() {
                     
                     $row.find('td:eq(2)').html(authorHtml).effect('highlight');
                     
-                    // Update content
+                    // 更新内容
                     var content = DOMPurify.sanitize(o.comment.content, {USE_PROFILES: {html: true}});
                     $row.find('.comment-content').html(content).effect('highlight');
                 }
             }
             
-            // Update card if exists
+            // 若存在则更新卡片
             if (_currentEditCardId) {
                 var $card = $('#' + _currentEditCardId);
                 if ($card.length > 0) {
-                    // Update data attribute
+                    // 更新 data 属性
                     var oldComment = JSON.parse($card.attr('data-comment'));
                     oldComment.author = formData.author;
                     oldComment.mail = formData.mail;
@@ -930,7 +930,7 @@ function submitEdit() {
                     oldComment.text = formData.text;
                     $card.attr('data-comment', JSON.stringify(oldComment));
                     
-                    // Update author info
+                    // 更新作者信息
                     var authorHtml = formData.url ? 
                         '<a href="' + formData.url + '" target="_blank" class="hover:underline">' + formData.author + '</a>' : 
                         formData.author;
@@ -942,7 +942,7 @@ function submitEdit() {
                         $card.find('.card-header .text-xs').html('');
                     }
                     
-                    // Update content
+                    // 更新内容
                     var content = DOMPurify.sanitize(o.comment.content, {USE_PROFILES: {html: true}});
                     $card.find('.card-content').html(content).effect('highlight');
                 }
@@ -1100,7 +1100,7 @@ $(document).ready(function () {
         booadminArmLinks('a.operate-delete, a.operate-approved, a.operate-waiting, a.operate-spam');
     }
 
-    // Modal close on background click
+    // 点击背景关闭模态框
     $('.comment-modal').on('click', function(e) {
         if ($(e.target).hasClass('comment-modal')) {
             if ($(this).attr('id') === 'replyModal') {
@@ -1115,7 +1115,7 @@ $(document).ready(function () {
         }
     });
     
-    // Message modal confirm button click
+    // 消息模态框确认按钮点击
     $('#messageModalConfirm').click(function() {
         var $modal = $('#messageModal');
         // 先快照数据, 再关闭弹窗, 最后执行跳转, 避免残留状态影响后续操作
@@ -1130,21 +1130,21 @@ $(document).ready(function () {
         }
     });
     
-    // Message modal cancel button click
+    // 消息模态框取消按钮点击
     $('#messageModalCancel').click(function() {
         closeMessageModal();
     });
     
-    // Enter key in reply textarea submits
+    // 回复文本框中按回车提交
     $('#replyText').on('keydown', function(e) {
         if (e.ctrlKey && e.keyCode === 13) {
             submitReply();
         }
     });
     
-    // ESC key closes modals
+    // ESC 键关闭模态框
     $(document).on('keydown', function(e) {
-        if (e.keyCode === 27) { // ESC key
+        if (e.keyCode === 27) { // ESC 键
             if ($('#replyModal').hasClass('active')) {
                 closeReplyModal();
             }

--- a/admin/manage-medias.php
+++ b/admin/manage-medias.php
@@ -98,11 +98,11 @@ $attachments = \Widget\Contents\Attachment\Admin::alloc();
                         <tbody class="divide-y divide-gray-100">
                             <?php if ($attachments->have()): ?>
                                 <?php 
-                                // Store attachments data for card view
+                                // 为卡片视图存储附件数据
                                 $attachmentsData = [];
                                 while ($attachments->next()): 
                                     $mime = \Typecho\Common::mimeIconType($attachments->attachment->mime);
-                                    // Store all necessary data in an array
+                                    // 将所有必要数据存入数组
                                     $attachmentsData[] = [
                                         'cid' => $attachments->cid,
                                         'title' => $attachments->title,
@@ -373,57 +373,23 @@ $attachments = \Widget\Contents\Attachment\Admin::alloc();
 include 'common-js.php';
 include 'table-js.php';
 ?>
-<!-- Operate Confirm Modal -->
-<div id="operate-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认操作'); ?></h3>
-        <p id="operate-confirm-message" class="text-discord-muted mb-6"></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-operate" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-operate" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 <script type="text/javascript">
 $(document).ready(function () {
-    // Operate confirmation modal
-    var operateHref = null;
-
-    function closeOperateModal() {
-        $('#operate-confirm-modal').addClass('hidden');
-        operateHref = null;
-    }
-
+    // 操作确认
     $('.btn-operate').click(function () {
         var t = $(this);
-        operateHref = t.attr('href');
-        $('#operate-confirm-message').text(t.attr('lang'));
-        $('#operate-confirm-modal').removeClass('hidden');
+        var href = t.attr('href');
+        BooAdmin.confirm({
+            title: '<?php _e('确认操作'); ?>',
+            message: t.attr('lang') || '<?php _e('确认要执行该操作吗?'); ?>',
+            confirmText: '<?php _e('确认'); ?>',
+            onConfirm: function () {
+                if (href) {
+                    window.location.href = href;
+                }
+            }
+        });
         return false;
-    });
-
-    $('#cancel-operate').click(closeOperateModal);
-
-    $('#confirm-operate').click(function () {
-        // 先快照目标, 再关闭并重置状态, 最后执行跳转
-        var href = operateHref;
-
-        closeOperateModal();
-
-        if (href) {
-            window.location.href = href;
-        }
-    });
-
-    // Close modal when clicking outside
-    $('#operate-confirm-modal').click(function (e) {
-        if (e.target === this) {
-            closeOperateModal();
-        }
     });
 });
 </script>

--- a/admin/manage-pages.php
+++ b/admin/manage-pages.php
@@ -104,10 +104,10 @@ $pages = \Widget\Contents\Page\Admin::alloc();
                         <tbody class="divide-y divide-gray-100">
                             <?php if ($pages->have()): ?>
                                 <?php 
-                                // Store pages data for card view
+                                // 为卡片视图存储页面数据
                                 $pagesData = [];
                                 while ($pages->next()): 
-                                    // Store all necessary data in an array
+                                    // 将所有必要数据存入数组
                                     $pagesData[] = [
                                         'cid' => $pages->cid,
                                         'title' => $pages->title,

--- a/admin/manage-posts.php
+++ b/admin/manage-posts.php
@@ -153,10 +153,10 @@ $isAllPosts = ('on' == $request->get('__typecho_all_posts') || 'on' == \Typecho\
                         <tbody class="divide-y divide-gray-100">
                             <?php if ($posts->have()): ?>
                                 <?php 
-                                // Store posts data for card view
+                                // 为卡片视图存储文章数据
                                 $postsData = [];
                                 while ($posts->next()): 
-                                    // Store all necessary data in an array
+                                    // 将所有必要数据存入数组
                                     $postsData[] = [
                                         'cid' => $posts->cid,
                                         'title' => $posts->title,

--- a/admin/manage-tags.php
+++ b/admin/manage-tags.php
@@ -106,21 +106,6 @@ include 'menu.php';
     <?php include 'copyright.php'; ?>
 </main>
 
-<div id="tags-confirm-modal" class="booadmin-modal hidden" role="dialog" aria-modal="true" aria-labelledby="tags-confirm-modal-title">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 id="tags-confirm-modal-title" class="text-lg font-bold text-discord-text mb-4"><?php _e('操作确认'); ?></h3>
-        <p id="tags-confirm-modal-message" class="text-discord-muted mb-6"><?php _e('请确认是否继续。'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="tags-modal-cancel" type="button" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="tags-modal-confirm" type="button" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认'); ?>
-            </button>
-        </div>
-    </div>
-</div>
-
 <style>
 /* 标签选中样式优化 */
 .tag-list li input:checked ~ .tag-item {
@@ -159,34 +144,22 @@ include 'form-js.php';
 (function () {
     $(document).ready(function () {
         var form = $('form[name="manage_tags"]'),
-            confirmModal = $('#tags-confirm-modal'),
-            confirmTitle = $('#tags-confirm-modal-title'),
-            confirmMessage = $('#tags-confirm-modal-message'),
-            confirmButton = $('#tags-modal-confirm'),
-            cancelButton = $('#tags-modal-cancel'),
-            pendingSubmit = null,
-            pendingActionEl = null,
             replayingNativeAction = false;
 
         function openModal(title, message, onConfirm, confirmOnly) {
-            confirmTitle.text(title);
-            confirmMessage.text(message);
-            pendingSubmit = onConfirm || null;
-
             if (confirmOnly) {
-                cancelButton.addClass('hidden');
-                confirmButton.text('<?php _e('我知道了'); ?>');
+                BooAdmin.alert({
+                    title: title,
+                    message: message,
+                    confirmText: '<?php _e('我知道了'); ?>'
+                });
             } else {
-                cancelButton.removeClass('hidden');
-                confirmButton.text('<?php _e('确认'); ?>');
+                BooAdmin.confirm({
+                    title: title,
+                    message: message,
+                    onConfirm: onConfirm
+                });
             }
-
-            confirmModal.removeClass('hidden').addClass('flex');
-        }
-
-        function closeModal() {
-            confirmModal.removeClass('flex').addClass('hidden');
-            pendingSubmit = null;
         }
 
         function hasSelectedTags() {
@@ -220,9 +193,8 @@ include 'form-js.php';
                 return false;
             }
 
-            pendingActionEl = actionLink;
             openModal('<?php _e('操作确认'); ?>', message, function () {
-                var target = pendingActionEl,
+                var target = actionLink,
                     originalLang;
 
                 if (!target || target.length === 0) {
@@ -241,14 +213,12 @@ include 'form-js.php';
                 if (typeof originalLang !== 'undefined') {
                     target.attr('lang', originalLang);
                 }
-
-                pendingActionEl = null;
             }, false);
 
             return false;
         });
 
-        // Reuse Typecho's row/select-all behavior.
+        // 复用 Typecho 的行/全选行为
         $('.tag-list').tableSelectable({
             checkEl     :   'input[type=checkbox]',
             rowEl       :   'li',
@@ -268,36 +238,12 @@ include 'form-js.php';
             requestBatchAction(btn.attr('rel'), message);
         });
 
-        confirmButton.on('click', function () {
-            var callback = pendingSubmit;
-            closeModal();
-            if (callback) {
-                callback();
-            }
-        });
-
-        cancelButton.on('click', function () {
-            closeModal();
-        });
-
-        confirmModal.on('click', function (e) {
-            if (e.target === this) {
-                closeModal();
-            }
-        });
-
-        $(document).on('keydown', function (e) {
-            if (e.key === 'Escape' && confirmModal.hasClass('flex')) {
-                closeModal();
-            }
-        });
-
         // 事件已绑定，解除这些操作链接的原生跳转保护
         if (window.booadminArmLinks) {
             booadminArmLinks('.js-tag-action');
         }
 
-        // Ensure form JS works correctly
+        // 确保表单 JS 正常工作
         $('.typecho-option input').first().focus();
 
         <?php if (isset($request->mid)): ?>

--- a/admin/manage-users.php
+++ b/admin/manage-users.php
@@ -99,7 +99,7 @@ $users = \Widget\Users\Admin::alloc();
                         <tbody class="divide-y divide-gray-100">
                             <?php if ($users->have()): ?>
                                 <?php
-                                // Store users data for card view
+                                // 为卡片视图存储用户数据
                                 $usersData = [];
                                 while ($users->next()):
                                     $groupClass = 'bg-gray-100 text-gray-500';

--- a/admin/media.php
+++ b/admin/media.php
@@ -69,7 +69,7 @@ include 'menu.php';
                             <label class="block text-sm font-medium text-gray-700 mb-1"><?php _e('文件链接'); ?></label>
                             <div class="flex">
                                 <input id="attachment-url" type="text" class="flex-1 px-3 py-2 border border-gray-300 bg-gray-50 text-sm text-gray-600 focus:outline-none focus:border-discord-accent" value="<?php $attachment->attachment->url(); ?>" readonly/>
-                                <button type="button" class="px-4 py-2 bg-gray-100 border border-l-0 border-gray-300 text-gray-600 hover:bg-gray-200 transition-colors text-sm font-medium" onclick="document.getElementById('attachment-url').select();document.execCommand('copy');document.getElementById('copy-success-modal').classList.remove('hidden'); setTimeout(function(){ document.getElementById('copy-success-modal').classList.add('hidden'); }, 2000);"><?php _e('复制'); ?></button>
+                                <button type="button" class="px-4 py-2 bg-gray-100 border border-l-0 border-gray-300 text-gray-600 hover:bg-gray-200 transition-colors text-sm font-medium" onclick="document.getElementById('attachment-url').select();document.execCommand('copy');BooAdmin.alert({title:'<?php _e('复制成功'); ?>',message:'<?php _e('已复制到剪贴板'); ?>',confirmText:'<?php _e('确定'); ?>'});"><?php _e('复制'); ?></button>
                             </div>
                         </div>
                     </div>
@@ -112,73 +112,27 @@ include 'menu.php';
 include 'common-js.php';
 include 'file-upload-js.php';
 ?>
-<!-- Delete Confirm Modal -->
-<div id="delete-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认删除'); ?></h3>
-        <p id="delete-confirm-message" class="text-discord-muted mb-6"></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-delete" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-delete" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认删除'); ?>
-            </button>
-        </div>
-    </div>
-</div>
-<!-- Copy Success Modal -->
-<div id="copy-success-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('复制成功'); ?></h3>
-        <p class="text-discord-muted mb-6"><?php _e('已复制到剪贴板'); ?></p>
-        <div class="flex justify-end">
-            <button class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm" onclick="document.getElementById('copy-success-modal').classList.add('hidden');">
-                <?php _e('确定'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 <script type="text/javascript">
     $(document).ready(function () {
         $('#attachment-url').click(function () {
             $(this).select();
         });
 
-        // Delete confirmation modal
-        var deleteHref = null;
-
-        function closeDeleteModal() {
-            $('#delete-confirm-modal').addClass('hidden');
-            deleteHref = null;
-        }
-
+        // 删除确认
         $('.operate-delete').click(function () {
             var t = $(this);
-            deleteHref = t.attr('href');
-            $('#delete-confirm-message').text(t.attr('lang'));
-            $('#delete-confirm-modal').removeClass('hidden');
+            var href = t.attr('href');
+            BooAdmin.confirm({
+                title: '<?php _e('确认删除'); ?>',
+                message: t.attr('lang') || '<?php _e('确认要删除该文件吗?'); ?>',
+                confirmText: '<?php _e('确认删除'); ?>',
+                onConfirm: function () {
+                    if (href) {
+                        window.location.href = href;
+                    }
+                }
+            });
             return false;
-        });
-
-        $('#cancel-delete').click(closeDeleteModal);
-
-        $('#confirm-delete').click(function () {
-            // 先快照目标, 再关闭并重置状态, 最后执行跳转
-            var href = deleteHref;
-
-            closeDeleteModal();
-
-            if (href) {
-                window.location.href = href;
-            }
-        });
-
-        // Close modal when clicking outside
-        $('#delete-confirm-modal').click(function (e) {
-            if (e.target === this) {
-                closeDeleteModal();
-            }
         });
 
         Typecho.uploadComplete = function (attachment) {

--- a/admin/menu.php
+++ b/admin/menu.php
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const sidebar = document.getElementById('sidebar');
     const toggleBtn = document.getElementById('sidebar-toggle');
     const overlay = document.getElementById('sidebar-overlay');
-    const mobileMenuBtn = document.getElementById('mobile-menu-btn'); // Will be added in header
+    const mobileMenuBtn = document.getElementById('mobile-menu-btn'); // 该按钮将在 header 中注入
     const nav = sidebar.querySelector('nav');
     const SIDEBAR_SCROLL_KEY = 'typecho_sidebar_scroll';
 
@@ -248,7 +248,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // 页面加载时恢复滚动位置
     restoreScrollPosition();
 
-    // Initial check for mobile
+    // 移动端初始检查
     if (window.innerWidth < 768) {
         closeSidebar();
     }

--- a/admin/table-js.php
+++ b/admin/table-js.php
@@ -3,76 +3,20 @@
 <script>
 (function () {
     $(document).ready(function () {
-        var sharedConfirmModal = $('#booadmin-table-confirm-modal');
-        var sharedConfirmMessage;
-        var sharedConfirmCancel;
-        var sharedConfirmSubmit;
-        var pendingAction = null;
-
-        function ensureSharedConfirmModal() {
-            if (sharedConfirmModal.length > 0) {
-                return;
-            }
-
-            sharedConfirmModal = $(
-                '<div id="booadmin-table-confirm-modal" class="booadmin-modal hidden" role="dialog" aria-modal="true" aria-labelledby="booadmin-table-confirm-title">' +
-                    '<div class="booadmin-dialog booadmin-dialog-sm">' +
-                        '<h3 id="booadmin-table-confirm-title" class="text-lg font-bold text-discord-text mb-4"><?php _e('操作确认'); ?></h3>' +
-                        '<p id="booadmin-table-confirm-message" class="text-discord-muted mb-6"><?php _e('请确认是否继续。'); ?></p>' +
-                        '<div class="flex justify-end space-x-3">' +
-                            '<button id="booadmin-table-confirm-cancel" type="button" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm"><?php _e('取消'); ?></button>' +
-                            '<button id="booadmin-table-confirm-submit" type="button" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm"><?php _e('确认'); ?></button>' +
-                        '</div>' +
-                    '</div>' +
-                '</div>'
-            ).appendTo('body');
-
-            sharedConfirmMessage = $('#booadmin-table-confirm-message');
-            sharedConfirmCancel = $('#booadmin-table-confirm-cancel');
-            sharedConfirmSubmit = $('#booadmin-table-confirm-submit');
-
-            function closeSharedConfirmModal() {
-                sharedConfirmModal.addClass('hidden').removeClass('flex');
-                pendingAction = null;
-            }
-
-            sharedConfirmCancel.on('click', closeSharedConfirmModal);
-            sharedConfirmSubmit.on('click', function () {
-                var action = pendingAction;
-                closeSharedConfirmModal();
-
-                if (action) {
-                    action();
-                }
-            });
-
-            sharedConfirmModal.on('click', function (e) {
-                if (e.target === this) {
-                    closeSharedConfirmModal();
-                }
-            });
-
-            $(document).on('keydown.tableConfirm', function (e) {
-                if (e.key === 'Escape' && sharedConfirmModal.hasClass('flex')) {
-                    closeSharedConfirmModal();
-                }
-            });
-        }
-
         function openSharedConfirmModal(message, onConfirm, alertOnly) {
-            ensureSharedConfirmModal();
-            sharedConfirmMessage.text(message || '<?php _e('请确认是否继续。'); ?>');
-            pendingAction = onConfirm || null;
-
             if (alertOnly) {
-                sharedConfirmCancel.addClass('hidden');
-                sharedConfirmSubmit.text('<?php _e('我知道了'); ?>');
+                BooAdmin.alert({
+                    title: '<?php _e('操作确认'); ?>',
+                    message: message || '<?php _e('请确认是否继续。'); ?>',
+                    confirmText: '<?php _e('我知道了'); ?>'
+                });
             } else {
-                sharedConfirmCancel.removeClass('hidden');
-                sharedConfirmSubmit.text('<?php _e('确认'); ?>');
+                BooAdmin.confirm({
+                    title: '<?php _e('操作确认'); ?>',
+                    message: message || '<?php _e('请确认是否继续。'); ?>',
+                    onConfirm: onConfirm
+                });
             }
-
-            sharedConfirmModal.removeClass('hidden').addClass('flex');
         }
 
         var EMPTY_SELECTION_MESSAGE = '<?php _e('请先选择至少一个条目。'); ?>';

--- a/admin/theme-editor.php
+++ b/admin/theme-editor.php
@@ -92,22 +92,6 @@ include 'menu.php';
                                     <?php endif; ?>
                                 </div>
                             </form>
-
-                            <!-- 保存确认提示框 -->
-                            <div id="save-confirm-modal" class="booadmin-modal hidden">
-                                <div class="booadmin-dialog booadmin-dialog-sm">
-                                    <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认保存'); ?></h3>
-                                    <p class="text-discord-muted mb-6"><?php _e('您确定要保存此文件吗？此操作不可逆。'); ?></p>
-                                    <div class="flex justify-end space-x-3">
-                                        <button type="button" id="cancel-save" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                                            <?php _e('取消'); ?>
-                                        </button>
-                                        <button type="button" id="confirm-save" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                                            <?php _e('确认保存'); ?>
-                                        </button>
-                                    </div>
-                                </div>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -167,35 +151,20 @@ document.addEventListener('fullscreenchange', function() {
 
 // 保存确认提示框
 const saveBtn = document.getElementById('save-btn');
-const saveConfirmModal = document.getElementById('save-confirm-modal');
-const cancelSave = document.getElementById('cancel-save');
-const confirmSave = document.getElementById('confirm-save');
 const themeForm = document.getElementById('theme');
 
 if (saveBtn) {
     saveBtn.addEventListener('click', function() {
-        saveConfirmModal.classList.remove('hidden');
-    });
-}
-
-if (cancelSave) {
-    cancelSave.addEventListener('click', function() {
-        saveConfirmModal.classList.add('hidden');
-    });
-}
-
-if (confirmSave) {
-    confirmSave.addEventListener('click', function() {
-        themeForm.submit();
-    });
-}
-
-// 点击模态框外部关闭
-if (saveConfirmModal) {
-    saveConfirmModal.addEventListener('click', function(e) {
-        if (e.target === saveConfirmModal) {
-            saveConfirmModal.classList.add('hidden');
-        }
+        BooAdmin.confirm({
+            title: '<?php _e('确认保存'); ?>',
+            message: '<?php _e('您确定要保存此文件吗？此操作不可逆。'); ?>',
+            confirmText: '<?php _e('确认保存'); ?>',
+            onConfirm: function () {
+                if (themeForm) {
+                    themeForm.submit();
+                }
+            }
+        });
     });
 }
 </script>

--- a/admin/write-js.php
+++ b/admin/write-js.php
@@ -38,10 +38,10 @@ $(document).ready(function() {
     // 聚焦
     $('#title').select();
 
-    // text 自动拉伸
+    // 正文编辑框自动拉伸
     Typecho.editorResize('text', '<?php $security->index('/action/ajax?do=editorResize'); ?>');
 
-    // tag autocomplete 提示
+    // 标签自动补全提示
     const tags = $('#tags'), tagsPre = [];
     
     if (tags.length > 0) {
@@ -79,7 +79,7 @@ $(document).ready(function() {
             prePopulate     :   tagsPre,
 
             onResult        :   function (result, query, val) {
-                // remove special chars
+                // 移除特殊字符
                 val = val.replace(/<|>|&|"|'/g, '');
 
                 if (!query) {
@@ -101,7 +101,7 @@ $(document).ready(function() {
             }
         });
 
-        // tag autocomplete 提示宽度设置
+        // 标签自动补全提示宽度设置
         $('#token-input-tags').focus(function() {
             const t = $('.token-input-dropdown'),
                 offset = t.outerWidth() - t.width();
@@ -278,7 +278,6 @@ $(document).ready(function() {
     $('<input name="timezone" type="hidden" />').appendTo(form).val(- (new Date).getTimezoneOffset() * 60);
 
     // 预览功能
-    const previewSaveModal = $('#preview-save-confirm-modal');
     const previewState = {
         overlay: null,
         container: null,
@@ -309,11 +308,6 @@ $(document).ready(function() {
 
     function getPreviewUrl(previewCid) {
         return './preview.php?cid=' + encodeURIComponent(previewCid);
-    }
-
-    function hidePreviewSaveConfirm() {
-        previewSaveModal.addClass('hidden');
-        previewState.saveCallback = null;
     }
 
     function togglePreviewFullScreen() {
@@ -457,50 +451,43 @@ $(document).ready(function() {
                 });
             };
 
-            previewSaveModal.removeClass('hidden');
+            BooAdmin.confirm({
+                title: '<?php _e('确认保存'); ?>',
+                message: '<?php _e('修改后的内容需要保存后才能预览, 是否保存?'); ?>',
+                confirmText: '<?php _e('确认保存'); ?>',
+                onConfirm: function () {
+                    const callback = previewState.saveCallback;
+                    previewState.saveCallback = null;
+                    if (callback) {
+                        callback();
+                    }
+                }
+            });
             return;
         }
 
         openPreview(resolvePreviewCid());
     });
 
-    $('#cancel-preview-save').on('click', hidePreviewSaveConfirm);
-
-    $('#confirm-preview-save').on('click', function () {
-        const callback = previewState.saveCallback;
-
-        hidePreviewSaveConfirm();
-
-        if (callback) {
-            callback();
-        }
-    });
-
-    previewSaveModal.on('click', function (e) {
-        if (e.target === this) {
-            hidePreviewSaveConfirm();
-        }
-    });
-
-    // Use 'on' for dynamic elements if needed, but direct click is fine for static
+    // 静态元素可直接绑定；动态元素如需再改用事件委托
     $(document).on('click', '.typecho-option-tabs button, .typecho-option-tabs li', function() {
         const $this = $(this);
         const isButton = $this.is('button');
         
         if (isButton) {
-            // New structure: button inside a flex container
+            // 新结构：按钮位于 flex 容器内
             const group = $this.parent();
-            // Reset all buttons in the group
+            // 重置分组内全部按钮样式
             group.find('button').removeClass('text-discord-text bg-white shadow-sm').addClass('text-gray-500 hover:text-discord-text');
-            // Activate clicked button
+            // 激活当前点击的按钮
             $this.removeClass('text-gray-500 hover:text-discord-text').addClass('text-discord-text bg-white shadow-sm');
         } else {
-            // Old structure: li inside ul
+            // 旧结构：li 位于 ul 内
             $this.siblings().removeClass('active');
             $this.addClass('active');
         }
         
-        // Hide all potential tab content containers
+        // 隐藏所有可能的标签页内容容器
         let targetSelector;
         if (isButton) {
             targetSelector = $this.data('target');
@@ -528,38 +515,20 @@ $(document).ready(function() {
         }
     });
     
-    // Draft delete confirmation modal
-    var draftDeleteHref = null;
-
-    function closeDraftDeleteModal() {
-        $('#draft-delete-confirm-modal').addClass('hidden');
-        draftDeleteHref = null;
-    }
-
+    // 草稿删除确认
     $('.edit-draft-notice a').click(function () {
-        draftDeleteHref = $(this).attr('href');
-        $('#draft-delete-confirm-modal').removeClass('hidden');
+        var href = $(this).attr('href');
+        BooAdmin.confirm({
+            title: '<?php _e('确认删除'); ?>',
+            message: '<?php _e('您确认要删除这份草稿吗?'); ?>',
+            confirmText: '<?php _e('确认删除'); ?>',
+            onConfirm: function () {
+                if (href) {
+                    window.location.href = href;
+                }
+            }
+        });
         return false;
-    });
-
-    $('#cancel-draft-delete').click(closeDraftDeleteModal);
-
-    $('#confirm-draft-delete').click(function () {
-        // 先快照目标, 再关闭并重置状态, 最后执行跳转
-        var href = draftDeleteHref;
-
-        closeDraftDeleteModal();
-
-        if (href) {
-            window.location.href = href;
-        }
-    });
-
-    // Close modal when clicking outside
-    $('#draft-delete-confirm-modal').click(function (e) {
-        if (e.target === this) {
-            closeDraftDeleteModal();
-        }
     });
 
     // 事件已绑定，解除这些操作链接的原生跳转保护
@@ -568,34 +537,4 @@ $(document).ready(function() {
     }
 });
 </script>
-<!-- Preview Save Confirm Modal -->
-<div id="preview-save-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认保存'); ?></h3>
-        <p class="text-discord-muted mb-6"><?php _e('修改后的内容需要保存后才能预览, 是否保存?'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-preview-save" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-preview-save" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认保存'); ?>
-            </button>
-        </div>
-    </div>
-</div>
-<!-- Draft Delete Confirm Modal -->
-<div id="draft-delete-confirm-modal" class="booadmin-modal hidden">
-    <div class="booadmin-dialog booadmin-dialog-sm">
-        <h3 class="text-lg font-bold text-discord-text mb-4"><?php _e('确认删除'); ?></h3>
-        <p class="text-discord-muted mb-6"><?php _e('您确认要删除这份草稿吗?'); ?></p>
-        <div class="flex justify-end space-x-3">
-            <button id="cancel-draft-delete" class="px-4 py-2 bg-gray-200 text-discord-text font-medium hover:bg-gray-300 transition-colors text-sm">
-                <?php _e('取消'); ?>
-            </button>
-            <button id="confirm-draft-delete" class="px-4 py-2 bg-discord-accent text-white font-medium hover:bg-blue-600 transition-colors text-sm">
-                <?php _e('确认删除'); ?>
-            </button>
-        </div>
-    </div>
-</div>
 


### PR DESCRIPTION
1. 重构前，后台里同一套"确认/提示弹窗"被重复实现了约 10 次（custom-fields、file-upload 删除与图片预览、table-js、write-js 两处、backup、media 删除与复制、theme-editor、manage-tags、manage-categories、manage-medias），每个都复制了几乎一样的「标题+正文+取消/确认按钮+点遮罩关闭+Esc 关闭」HTML 与脚本，是维护负担与不一致的主要来源。

- 新建共享库，由 common-js.php 统一加载，并注入翻译与通知别名：
- BooAdmin.confirm({ title, message, confirmText, cancelText, onConfirm }) —— 确认框 BooAdmin.alert({ title, message,  confirmText, - onConfirm }) —— 提示框（单按钮） BooAdmin.Modal.create({...}) —— 高级/自定义弹窗（图片预览即走这里） BooAdmin.setI18n(...) / BooAdmin.notify（别名 TypechoNotification） 内部用单例共享模态框 + 每实例独立控制器，避免 DOM 累积；封装了遮罩点击关闭、Esc 关闭、确认回调可 return false 阻止关闭（用于"请求中保持弹窗"）等通用行为。

2. 对 admin 目录下所有 PHP 模板/分片的内联 <script> 注释，以及自研 JS（neo-theme.js、booadmin.js）进行注释标准化：

- 统一语言：中文为主，技术术语保留英文（NProgress、dropdownMenu、localStorage、KaTeX、Passkey、ESC、Markdown、BooAdmin、URL、API、DOM 等）。
- 统一风格：单行用 //（后接一个空格），函数/多行说明用 JSDoc（/** … */）；术语大小写规范（nprogress → NProgress）。
- 将约 80+ 处纯英文/中英混用注释中文化，覆盖 common-js、write-js、file-upload-js、editor-js、form-js、backup、theme-editor、media、manage-tags/categories/medias/users/posts/pages/comments、menu、preview、login、index 等内联脚本。
- 仅改动 <script> 内注释，未触碰 PHP/HTML 模板注释与第三组件库。